### PR TITLE
Add a GCD check to the Lucas test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Under construction.
+### Fixed
+
+- Added a `gcd(Q, n) == 1` check to the Lucas test. (#[11])
+
+
+[#11]: https://github.com/nucypher/rust-umbral/pull/11
 
 
 ## [0.1.0] - 2023-01-20

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rand_chacha = "0.3"
 criterion = { version = "0.4", features = ["html_reports"] }
 num-modular = { version = "0.5", features = ["num-bigint"] }
 num-bigint = "0.4"
+num-integer = "0.1"
 proptest = "1"
 num-prime = "0.4.3"
 

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -1,6 +1,7 @@
 //! Components to build your own primality test.
 //! Handle with care.
 
+mod gcd;
 mod jacobi;
 mod lucas;
 mod miller_rabin;

--- a/src/hazmat/gcd.rs
+++ b/src/hazmat/gcd.rs
@@ -1,0 +1,86 @@
+use crypto_bigint::{Limb, NonZero, Uint};
+
+/// Calculates the greatest common divisor of `n` and `m`.
+/// By definition, `gcd(0, m) == m`.
+/// `n` must be non-zero.
+pub(crate) fn gcd<const L: usize>(n: &Uint<L>, m: u32) -> u32 {
+    // This is an internal function, and it will never be called with `m = 0`.
+    // Allowing `m = 0` would require us to have the return type of `Uint<L>`
+    // (since `gcd(n, 0) = n`).
+    debug_assert!(m != 0);
+
+    // This we can check since it doesn't affect the return type,
+    // even though `n` will not be 0 either in the application.
+    if n == &Uint::<L>::ZERO {
+        return m;
+    }
+
+    // Normalize input: the resulting (a, b) are both small, a >= b, and b != 0.
+    let (mut a, mut b): (u32, u32) = if n.bits() > (u32::BITS as usize) {
+        // `m` is non-zero, so we can unwrap.
+        let (_quo, n) = n.div_rem_limb(NonZero::new(Limb::from(m)).unwrap());
+        // `n` is a remainder of a division by `u32`, so it can be safely cast to `u32`.
+        let b: u32 = n.0.try_into().unwrap();
+        (m, b)
+    } else {
+        // In this branch `n` is 32 bits or shorter,
+        // so we can safely take the first limb and cast it to u32.
+        let n: u32 = n.as_words()[0].try_into().unwrap();
+        if n > m {
+            (n, m)
+        } else {
+            (m, n)
+        }
+    };
+
+    // Euclidean algorithm.
+    // Binary GCD algorithm could be used here,
+    // but the performance impact of this code is negligible.
+    loop {
+        let r = a % b;
+        if r == 0 {
+            return b;
+        }
+        (a, b) = (b, r)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crypto_bigint::{Encoding, U128};
+    use num_bigint::BigUint;
+    use num_integer::Integer;
+    use proptest::prelude::*;
+
+    use super::gcd;
+
+    #[test]
+    fn corner_cases() {
+        assert_eq!(gcd(&U128::from(0u64), 5), 5);
+        assert_eq!(gcd(&U128::from(1u64), 11 * 13 * 19), 1);
+        assert_eq!(gcd(&U128::from(7u64 * 11 * 13), 1), 1);
+        assert_eq!(gcd(&U128::from(7u64 * 11 * 13), 11 * 13 * 19), 11 * 13);
+    }
+
+    prop_compose! {
+        fn uint()(bytes in any::<[u8; 16]>()) -> U128 {
+            U128::from_le_slice(&bytes) | U128::ONE
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn fuzzy(m in any::<u32>(), n in uint()) {
+            if m == 0 {
+                return Ok(());
+            }
+
+            let m_bi = BigUint::from(m);
+            let n_bi = BigUint::from_bytes_be(n.to_be_bytes().as_ref());
+            let gcd_ref: u32 = n_bi.gcd(&m_bi).try_into().unwrap();
+
+            let gcd_test = gcd(&n, m);
+            assert_eq!(gcd_test, gcd_ref);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1 

According to Robert Baillie himself (from private correspondence), strictly speaking the `gcd(Q, n) == 1` check is necessary. Of course, in practice the Lucas test will be executed on a pre-sieved `n`, and `Q` is always small, so this condition is satisfied automatically. But in order to avoid having implicit assumptions in the code (since `lucas_test()` is public), this PR adds the GCD check. The performance impact is negligible, so why not.