### PR TITLE
Better sieving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bumped `crypto-bigint` to 0.5.0-pre.2 with the corresponding changes in the API. (#[13])
+- `Sieve::new()` now does not panic; if the parameters imply an empty output, that's what the iterator generates. (#[14])
 
 
 ### Added
@@ -19,11 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Added a `gcd(Q, n) == 1` check to the Lucas test. (#[11])
+- Added a simple 3 mod 4 check for safe primes, speeding up their generation. (#[14])
+- Fixed multiple corner cases in `Sieve` for small ranges. (#[14])
 
 
 [#11]: https://github.com/nucypher/rust-umbral/pull/11
 [#12]: https://github.com/nucypher/rust-umbral/pull/12
 [#13]: https://github.com/nucypher/rust-umbral/pull/13
+[#14]: https://github.com/nucypher/rust-umbral/pull/14
 
 
 ## [0.1.0] - 2023-01-20

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -38,3 +38,18 @@ impl Primality {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloc::format;
+
+    use super::Primality;
+
+    #[test]
+    fn primality_derived_traits() {
+        assert_eq!(format!("{:?}", Primality::Prime), "Prime");
+        assert_eq!(Primality::Prime, Primality::Prime);
+        assert!(Primality::Prime != Primality::ProbablyPrime);
+        assert_eq!(Primality::Prime.clone(), Primality::Prime);
+    }
+}

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -17,7 +17,7 @@ use super::Primality;
 ///   C. Pomerance, J. L. Selfridge, S. S. Wagstaff "The Pseudoprimes to 25*10^9",
 ///   Math. Comp. 35 1003-1026 (1980),
 ///   DOI: [10.2307/2006210](https://dx.doi.org/10.2307/2006210)
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct MillerRabin<const L: usize> {
     candidate: Uint<L>,
     montgomery_params: DynResidueParams<L>,
@@ -106,6 +106,9 @@ fn decompose<const L: usize>(n: &Uint<L>) -> (u32, Uint<L>) {
 
 #[cfg(test)]
 mod tests {
+
+    use alloc::format;
+
     use crypto_bigint::{Uint, U1024, U128, U1536, U64};
     use rand_chacha::ChaCha8Rng;
     use rand_core::{CryptoRngCore, SeedableRng};
@@ -115,6 +118,13 @@ mod tests {
 
     use super::MillerRabin;
     use crate::hazmat::{primes, pseudoprimes, random_odd_uint, Sieve};
+
+    #[test]
+    fn miller_rabin_derived_traits() {
+        let mr = MillerRabin::new(&U64::ONE);
+        assert!(format!("{mr:?}").starts_with("MillerRabin"));
+        assert_eq!(mr.clone(), mr);
+    }
 
     fn is_spsp(num: u32) -> bool {
         pseudoprimes::STRONG_BASE_2.iter().any(|x| *x == num)

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -4,7 +4,7 @@ use rand_core::CryptoRngCore;
 
 use crypto_bigint::{
     modular::runtime_mod::{DynResidue, DynResidueParams},
-    Integer, NonZero, RandomMod, Uint,
+    Integer, NonZero, RandomMod, Uint, Zero,
 };
 
 use super::Primality;
@@ -91,6 +91,11 @@ fn decompose<const L: usize>(n: &Uint<L>) -> (u32, Uint<L>) {
     let mut d = n.wrapping_sub(&Uint::<L>::ONE);
     let mut s = 0;
 
+    // Corner case, exit early to prevent being stuck in the loop.
+    if d.is_zero().into() {
+        return (0, Uint::<L>::ZERO);
+    }
+
     while d.is_even().into() {
         d >>= 1;
         s += 1;
@@ -156,7 +161,7 @@ mod tests {
     fn trivial() {
         let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
         let start: U1024 = random_odd_uint(&mut rng, 1024);
-        for num in Sieve::new(&start, 1024).take(10) {
+        for num in Sieve::new(&start, 1024, false).take(10) {
             let mr = MillerRabin::new(&num);
 
             // Trivial tests, must always be true.

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -13,7 +13,13 @@ use crate::hazmat::{
 
 /// Returns a random odd integer with given bit length
 /// (that is, with both `0` and `bit_length-1` bits set).
+///
+/// Panics if `bit_length` is 0 or is greater than the bit size of the target `Uint`.
 pub fn random_odd_uint<const L: usize>(rng: &mut impl CryptoRngCore, bit_length: usize) -> Uint<L> {
+    if bit_length == 0 {
+        panic!("Bit length must be non-zero");
+    }
+
     if bit_length > Uint::<L>::BITS {
         panic!(
             "The requested bit length ({}) is larger than the chosen Uint size",
@@ -46,8 +52,11 @@ pub struct Sieve<const L: usize> {
     base: Uint<L>,
     incr: Residue,
     incr_limit: Residue,
+    safe_primes: bool,
     residues: Vec<SmallPrime>,
     max_bit_length: usize,
+    produces_nothing: bool,
+    starts_from_exception: bool,
     last_round: bool,
 }
 
@@ -61,57 +70,106 @@ const INCR_LIMIT: Residue = Residue::MAX - SMALL_PRIMES[SMALL_PRIMES.len() - 1] 
 
 impl<const L: usize> Sieve<L> {
     /// Creates a new sieve, iterating from `start` and
-    /// until the last number with `max_bit_length` bits.
-    pub fn new(start: &Uint<L>, max_bit_length: usize) -> Self {
-        // Since 2 is not in `SMALL_PRIMES`, we need the starting number to be pre-selected
-        // to not be divisible by it.
-        if start.is_even().into() {
-            panic!("Sieving must be started from an odd number");
+    /// until the last number with `max_bit_length` bits,
+    /// producing numbers that are not non-trivial multiples
+    /// of a list of small primes in the range `[2, start)`.
+    ///
+    /// Note that `start` is adjusted to `2`, or the next `1 mod 2` number (`safe_prime = false`);
+    /// and `5`, or `3 mod 4` number (`safe_prime = true`).
+    ///
+    /// If `safe_primes` is `true`, it only produces the candidates
+    /// that can possibly be safe primes (that is, 5, and those equal to 3 modulo 4).
+    pub fn new(start: &Uint<L>, max_bit_length: usize, safe_primes: bool) -> Self {
+        let mut base = *start;
+
+        // This is easier than making all the methods generic enough to handle these corner cases.
+        let produces_nothing = max_bit_length < base.bits()
+            || (!safe_primes && max_bit_length < 2)
+            || (safe_primes && max_bit_length < 3);
+
+        // Add exceptions to the produced candidates - the only ones that don't fit
+        // the general pattern of incrementing the base by 2 or by 4.
+        let mut starts_from_exception = false;
+        if !safe_primes {
+            if base <= Uint::<L>::from(2u32) {
+                starts_from_exception = true;
+                base = Uint::<L>::from(3u32);
+            } else {
+                // Adjust the base so that we hit correct numbers when incrementing it by 2.
+                base |= Uint::<L>::ONE;
+            }
+        } else if base <= Uint::<L>::from(5u32) {
+            starts_from_exception = true;
+            base = Uint::<L>::from(7u32);
+        } else {
+            // Adjust the base so that we hit correct numbers when incrementing it by 4.
+            // If we are looking for safe primes, we are only interested
+            // in the numbers == 3 mod 4.
+            base |= Uint::<L>::from(3u32);
         }
 
+        // Only calculate residues by primes up to and not including `base`,
+        // because when we only have the resiude,
+        // we cannot distinguish between a prime itself and a multiple of that prime.
+        let residues_len = SMALL_PRIMES
+            .iter()
+            .enumerate()
+            .find(|(_i, p)| Uint::<L>::from(**p) >= base)
+            .map(|(i, _p)| i)
+            .unwrap_or(SMALL_PRIMES.len());
+
         Self {
-            base: *start,
+            base,
             incr: 0, // This will ensure that `update_residues()` is called right away.
             incr_limit: 0,
-            residues: vec![0; SMALL_PRIMES.len()],
+            safe_primes,
+            residues: vec![0; residues_len],
             max_bit_length,
+            produces_nothing,
+            starts_from_exception,
             last_round: false,
         }
     }
 
     fn update_residues(&mut self) -> bool {
-        if self.incr >= self.incr_limit {
-            if self.last_round {
-                return false;
-            }
-
-            // Set the new base.
-            self.base = self.base.wrapping_add(&self.incr.into());
-            self.incr = 0;
-
-            // Re-calculate residues.
-            for (i, small_prime) in SMALL_PRIMES.iter().enumerate().take(self.residues.len()) {
-                let (_quo, rem) = self
-                    .base
-                    .div_rem_limb(NonZero::new(Limb::from(*small_prime)).unwrap());
-                self.residues[i] = rem.0 as SmallPrime;
-            }
-
-            // Find the increment limit.
-            let max_value = (Uint::<L>::ONE << self.max_bit_length).wrapping_sub(&Uint::<L>::ONE);
-            let incr_limit = max_value.wrapping_sub(&self.base);
-            self.incr_limit = if incr_limit > INCR_LIMIT.into() {
-                INCR_LIMIT
-            } else {
-                // We are close to `2^max_bit_length - 1`.
-                // Mark this round as the last.
-                self.last_round = true;
-                // Can unwrap here since we just checked above that `incr_limit <= INCR_LIMIT`,
-                // and `INCR_LIMIT` fits into `Residue`.
-                let incr_limit_small: Residue = incr_limit.as_words()[0].try_into().unwrap();
-                incr_limit_small
-            };
+        if self.incr_limit != 0 && self.incr <= self.incr_limit {
+            return true;
         }
+
+        if self.last_round {
+            return false;
+        }
+
+        // Set the new base.
+        self.base = self.base.wrapping_add(&self.incr.into());
+
+        self.incr = 0;
+
+        // Re-calculate residues.
+        for (i, small_prime) in SMALL_PRIMES.iter().enumerate().take(self.residues.len()) {
+            let (_quo, rem) = self
+                .base
+                .div_rem_limb(NonZero::new(Limb::from(*small_prime)).unwrap());
+            self.residues[i] = rem.0 as SmallPrime;
+        }
+
+        // Find the increment limit.
+        // Note that the max value is the same regardless of the value of `self.safe_prime`,
+        // since `(2^n - 1) = 3 mod 4` (for n > 1).
+        let max_value = (Uint::<L>::ONE << self.max_bit_length).wrapping_sub(&Uint::<L>::ONE);
+        let incr_limit = max_value.wrapping_sub(&self.base);
+        self.incr_limit = if incr_limit > INCR_LIMIT.into() {
+            INCR_LIMIT
+        } else {
+            // We are close to `2^max_bit_length - 1`.
+            // Mark this round as the last.
+            self.last_round = true;
+            // Can unwrap here since we just checked above that `incr_limit <= INCR_LIMIT`,
+            // and `INCR_LIMIT` fits into `Residue`.
+            let incr_limit_small: Residue = incr_limit.as_words()[0].try_into().unwrap();
+            incr_limit_small
+        };
+
         true
     }
 
@@ -134,15 +192,26 @@ impl<const L: usize> Sieve<L> {
         } else {
             Some(self.base.wrapping_add(&self.incr.into()))
         };
-        self.incr += 2;
+
+        // If we are looking for safe primes, we are only interested in the numbers == 3 mod 4.
+        self.incr += if self.safe_primes { 4 } else { 2 };
         result
     }
-}
 
-impl<const L: usize> Iterator for Sieve<L> {
-    type Item = Uint<L>;
+    fn next(&mut self) -> Option<Uint<L>> {
+        // Corner cases handled here
 
-    fn next(&mut self) -> Option<Self::Item> {
+        if self.produces_nothing {
+            return None;
+        }
+
+        if self.starts_from_exception {
+            self.starts_from_exception = false;
+            return Some(Uint::<L>::from(if self.safe_primes { 5u32 } else { 2u32 }));
+        }
+
+        // Main loop
+
         while self.update_residues() {
             match self.maybe_next() {
                 Some(x) => return Some(x),
@@ -153,7 +222,15 @@ impl<const L: usize> Iterator for Sieve<L> {
     }
 }
 
-/// Performs trial division of the given number by a list of small primes.
+impl<const L: usize> Iterator for Sieve<L> {
+    type Item = Uint<L>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Sieve::<L>::next(self)
+    }
+}
+
+/// Performs trial division of the given number by a list of small primes starting from 2.
 /// Returns `Some(primality)` if there was a definitive conclusion about `num`'s primality,
 /// and `None` otherwise.
 pub fn sieve_once<const L: usize>(num: &Uint<L>) -> Option<Primality> {
@@ -186,7 +263,7 @@ mod tests {
     use crypto_bigint::U64;
     use num_prime::nt_funcs::factorize64;
     use rand_chacha::ChaCha8Rng;
-    use rand_core::SeedableRng;
+    use rand_core::{OsRng, SeedableRng};
 
     use super::{random_odd_uint, Sieve};
     use crate::hazmat::precomputed::SMALL_PRIMES;
@@ -197,7 +274,7 @@ mod tests {
 
         let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
         let start: U64 = random_odd_uint(&mut rng, 32);
-        for num in Sieve::new(&start, 32).take(100) {
+        for num in Sieve::new(&start, 32, false).take(100) {
             let num_u64: u64 = num.into();
             assert!(num_u64.leading_zeros() == 32);
 
@@ -206,5 +283,73 @@ mod tests {
 
             assert!(factors[0] > max_prime as u64);
         }
+    }
+
+    fn check_sieve(start: u32, bit_length: usize, safe_prime: bool, reference: &[u32]) {
+        let test = Sieve::new(&U64::from(start), bit_length, safe_prime).collect::<Vec<_>>();
+        assert_eq!(test.len(), reference.len());
+        for (x, y) in test.iter().zip(reference.iter()) {
+            assert_eq!(x, &U64::from(*y));
+        }
+    }
+
+    #[test]
+    fn empty_sequence() {
+        check_sieve(1, 1, false, &[]); // no primes of 1 bits
+        check_sieve(1, 2, true, &[]); // no safe primes of 2 bits
+        check_sieve(64, 6, true, &[]); // 64 is 7 bits long
+    }
+
+    #[test]
+    fn small_range() {
+        check_sieve(1, 2, false, &[2, 3]);
+        check_sieve(2, 2, false, &[2, 3]);
+        check_sieve(3, 2, false, &[3]);
+
+        check_sieve(1, 3, false, &[2, 3, 5, 7]);
+        check_sieve(3, 3, false, &[3, 5, 7]);
+        check_sieve(5, 3, false, &[5, 7]);
+        check_sieve(7, 3, false, &[7]);
+
+        check_sieve(1, 4, false, &[2, 3, 5, 7, 9, 11, 13, 15]);
+        check_sieve(3, 4, false, &[3, 5, 7, 9, 11, 13, 15]);
+        check_sieve(5, 4, false, &[5, 7, 11, 13]);
+        check_sieve(7, 4, false, &[7, 11, 13]);
+        check_sieve(9, 4, false, &[11, 13]);
+        check_sieve(13, 4, false, &[13]);
+        check_sieve(15, 4, false, &[]);
+
+        check_sieve(1, 3, true, &[5, 7]);
+        check_sieve(3, 3, true, &[5, 7]);
+        check_sieve(5, 3, true, &[5, 7]);
+        check_sieve(7, 3, true, &[7]);
+
+        // start is adjusted to 5 here, so multiples of 3 can be excluded
+        check_sieve(1, 4, true, &[5, 7, 11]);
+
+        check_sieve(5, 4, true, &[5, 7, 11]);
+        check_sieve(7, 4, true, &[7, 11]);
+        check_sieve(9, 4, true, &[11]);
+        check_sieve(13, 4, true, &[]);
+    }
+
+    #[test]
+    fn random_below_max_length() {
+        for _ in 0..10 {
+            let r: U64 = random_odd_uint(&mut OsRng, 50);
+            assert_eq!(r.bits(), 50);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "Bit length must be non-zero")]
+    fn random_odd_uint_0bits() {
+        let _p: U64 = random_odd_uint(&mut OsRng, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "The requested bit length (65) is larger than the chosen Uint size")]
+    fn random_odd_uint_too_many_bits() {
+        let _p: U64 = random_odd_uint(&mut OsRng, 65);
     }
 }

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -44,7 +44,7 @@ pub fn random_odd_uint<const L: usize>(rng: &mut impl CryptoRngCore, bit_length:
 
 /// An iterator returning numbers with up to and including given bit length,
 /// starting from a given number, that are not multiples of the first 2048 small primes.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Sieve<const L: usize> {
     // Instead of dividing `Uint` by small primes every time (which is slow),
     // we keep a "base" and a small increment separately,
@@ -258,6 +258,7 @@ pub fn sieve_once<const L: usize>(num: &Uint<L>) -> Option<Primality> {
 #[cfg(test)]
 mod tests {
 
+    use alloc::format;
     use alloc::vec::Vec;
 
     use crypto_bigint::U64;
@@ -351,5 +352,12 @@ mod tests {
     #[should_panic(expected = "The requested bit length (65) is larger than the chosen Uint size")]
     fn random_odd_uint_too_many_bits() {
         let _p: U64 = random_odd_uint(&mut OsRng, 65);
+    }
+
+    #[test]
+    fn sieve_derived_traits() {
+        let s = Sieve::new(&U64::ONE, 10, false);
+        assert!(format!("{s:?}").starts_with("Sieve"));
+        assert_eq!(s.clone(), s);
     }
 }

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -281,6 +281,15 @@ mod tests {
     }
 
     #[test]
+    fn inconclusive_sieving_result() {
+        // Coverage test.
+        // This number is a product of two primes larger than the maximum prime in `SMALL_PRIMES`,
+        // so the initial sieving cannot tell if it is prime or not,
+        // and a full primality test is run.
+        assert!(!is_safe_prime(&U64::from(17881u32 * 17891u32)));
+    }
+
+    #[test]
     #[should_panic(expected = "`bit_length` must be 2 or greater")]
     fn generate_prime_too_few_bits() {
         let _p: U64 = prime_with_rng(&mut OsRng, 1);

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -45,11 +45,16 @@ pub fn is_safe_prime<const L: usize>(num: &Uint<L>) -> bool {
 
 /// Returns a random prime of size `bit_length` using the provided RNG.
 ///
+/// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
+///
 /// See [`is_prime_with_rng`] for details about the performed checks.
 pub fn prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, bit_length: usize) -> Uint<L> {
+    if bit_length < 2 {
+        panic!("`bit_length` must be 2 or greater.");
+    }
     loop {
         let start: Uint<L> = random_odd_uint(rng, bit_length);
-        let sieve = Sieve::new(&start, bit_length);
+        let sieve = Sieve::new(&start, bit_length, false);
         for num in sieve {
             if _is_prime_with_rng(rng, &num) {
                 return num;
@@ -61,18 +66,27 @@ pub fn prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, bit_length: 
 /// Returns a random safe prime (that is, such that `(n - 1) / 2` is also prime)
 /// of size `bit_length` using the provided RNG.
 ///
+/// Panics if `bit_length` is less than 3, or is greater than the bit size of the target `Uint`.
+///
 /// See [`is_prime_with_rng`] for details about the performed checks.
 pub fn safe_prime_with_rng<const L: usize>(
     rng: &mut impl CryptoRngCore,
     bit_length: usize,
 ) -> Uint<L> {
+    if bit_length < 3 {
+        panic!("`bit_length` must be 3 or greater.");
+    }
     loop {
         let start: Uint<L> = random_odd_uint(rng, bit_length);
-        let sieve = Sieve::new(&start, bit_length);
+        let sieve = Sieve::new(&start, bit_length, true);
         for num in sieve {
-            if _is_safe_prime_with_rng(rng, &num) {
-                return num;
+            if !_is_prime_with_rng(rng, &num) {
+                continue;
             }
+            if !is_prime_with_rng(rng, &(num >> 1)) {
+                continue;
+            }
+            return num;
         }
     }
 }
@@ -114,21 +128,32 @@ pub fn is_prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, num: &Uin
 ///
 /// See [`is_prime_with_rng`] for details about the performed checks.
 pub fn is_safe_prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, num: &Uint<L>) -> bool {
-    if let Some(primality) = sieve_once(num) {
-        return primality.is_probably_prime();
+    // Since, by the definition of safe prime, `(num - 1) / 2` must also be prime,
+    // and therefore odd, `num` has to be equal to 3 modulo 4.
+    // 5 is the only exception, so we check for it.
+    if num == &Uint::<L>::from(5u32) {
+        return true;
     }
-    _is_safe_prime_with_rng(rng, num)
-}
-
-/// Checks for safe prime assuming that `num` was already pre-sieved.
-fn _is_safe_prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, num: &Uint<L>) -> bool {
-    debug_assert!(bool::from(num.is_odd()));
-    if !_is_prime_with_rng(rng, num) {
+    if num.as_words()[0] & 3 != 3 {
         return false;
     }
+
+    if let Some(primality) = sieve_once(num) {
+        // If sieving returns a definite conclusion about `num`, use it.
+        if !primality.is_probably_prime() {
+            return false;
+        }
+    } else {
+        // Otherwise run the rest of the checks.
+        if !_is_prime_with_rng(rng, num) {
+            return false;
+        }
+    };
+
     if !is_prime_with_rng(rng, &(num >> 1)) {
         return false;
     }
+
     true
 }
 
@@ -150,9 +175,11 @@ fn _is_prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, num: &Uint<L
 
 #[cfg(test)]
 mod tests {
-    use crypto_bigint::{CheckedAdd, Uint, U128, U64};
+    use crypto_bigint::{CheckedAdd, Uint, Word, U128, U64};
+    use num_prime::nt_funcs::is_prime64;
+    use rand_core::OsRng;
 
-    use super::{is_prime, is_safe_prime, prime, safe_prime};
+    use super::{is_prime, is_safe_prime, prime, prime_with_rng, safe_prime, safe_prime_with_rng};
     use crate::hazmat::{primes, pseudoprimes};
 
     fn test_large_primes<const L: usize>(nums: &[Uint<L>]) {
@@ -235,6 +262,71 @@ mod tests {
             let p: U128 = safe_prime(bit_length);
             assert!(p.bits_vartime() == bit_length);
             assert!(is_safe_prime(&p));
+        }
+    }
+
+    #[test]
+    fn corner_cases_is_prime() {
+        for num in 0u64..30 {
+            let is_prime_ref = is_prime64(num);
+            let is_safe_prime_ref = is_prime_ref && is_prime64(num / 2);
+
+            let num_uint = U64::from(num);
+            let is_prime_test = is_prime(&num_uint);
+            let is_safe_prime_test = is_safe_prime(&num_uint);
+
+            assert_eq!(is_prime_ref, is_prime_test);
+            assert_eq!(is_safe_prime_ref, is_safe_prime_test);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "`bit_length` must be 2 or greater")]
+    fn generate_prime_too_few_bits() {
+        let _p: U64 = prime_with_rng(&mut OsRng, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "`bit_length` must be 3 or greater")]
+    fn generate_safe_prime_too_few_bits() {
+        let _p: U64 = safe_prime_with_rng(&mut OsRng, 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "The requested bit length (65) is larger than the chosen Uint size")]
+    fn generate_prime_too_many_bits() {
+        let _p: U64 = prime_with_rng(&mut OsRng, 65);
+    }
+
+    #[test]
+    #[should_panic(expected = "The requested bit length (65) is larger than the chosen Uint size")]
+    fn generate_safe_prime_too_many_bits() {
+        let _p: U64 = safe_prime_with_rng(&mut OsRng, 65);
+    }
+
+    fn is_prime_ref(num: Word) -> bool {
+        num_prime::nt_funcs::is_prime(&num, None).probably()
+    }
+
+    #[test]
+    fn corner_cases_generate_prime() {
+        for bits in 2usize..5 {
+            for _ in 0..100 {
+                let p: U64 = prime(bits);
+                let p_word = p.as_words()[0];
+                assert!(is_prime_ref(p_word));
+            }
+        }
+    }
+
+    #[test]
+    fn corner_cases_generate_safe_prime() {
+        for bits in 3usize..5 {
+            for _ in 0..100 {
+                let p: U64 = safe_prime(bits);
+                let p_word = p.as_words()[0];
+                assert!(is_prime_ref(p_word) && is_prime_ref(p_word / 2));
+            }
         }
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -24,12 +24,12 @@ pub trait RandomPrimeWithRng {
     /// Checks probabilistically if the given number is prime using the provided RNG.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn is_prime_with_rng(rng: &mut impl CryptoRngCore, num: &Self) -> bool;
+    fn is_prime_with_rng(&self, rng: &mut impl CryptoRngCore) -> bool;
 
     /// Checks probabilistically if the given number is a safe prime using the provided RNG.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn is_safe_prime_with_rng(rng: &mut impl CryptoRngCore, num: &Self) -> bool;
+    fn is_safe_prime_with_rng(&self, rng: &mut impl CryptoRngCore) -> bool;
 }
 
 impl<const L: usize> RandomPrimeWithRng for Uint<L> {
@@ -39,10 +39,30 @@ impl<const L: usize> RandomPrimeWithRng for Uint<L> {
     fn safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self {
         safe_prime_with_rng(rng, bit_length)
     }
-    fn is_prime_with_rng(rng: &mut impl CryptoRngCore, num: &Self) -> bool {
-        is_prime_with_rng(rng, num)
+    fn is_prime_with_rng(&self, rng: &mut impl CryptoRngCore) -> bool {
+        is_prime_with_rng(rng, self)
     }
-    fn is_safe_prime_with_rng(rng: &mut impl CryptoRngCore, num: &Self) -> bool {
-        is_safe_prime_with_rng(rng, num)
+    fn is_safe_prime_with_rng(&self, rng: &mut impl CryptoRngCore) -> bool {
+        is_safe_prime_with_rng(rng, self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crypto_bigint::U64;
+    use rand_core::OsRng;
+
+    use super::RandomPrimeWithRng;
+
+    #[test]
+    fn uint_impl() {
+        assert!(!U64::from(15u32).is_prime_with_rng(&mut OsRng));
+        assert!(U64::from(19u32).is_prime_with_rng(&mut OsRng));
+
+        assert!(!U64::from(13u32).is_safe_prime_with_rng(&mut OsRng));
+        assert!(U64::from(11u32).is_safe_prime_with_rng(&mut OsRng));
+
+        assert!(U64::prime_with_rng(&mut OsRng, 10).is_prime_with_rng(&mut OsRng));
+        assert!(U64::safe_prime_with_rng(&mut OsRng, 10).is_safe_prime_with_rng(&mut OsRng));
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -8,11 +8,15 @@ use crate::{is_prime_with_rng, is_safe_prime_with_rng, prime_with_rng, safe_prim
 pub trait RandomPrimeWithRng {
     /// Returns a random prime of size `bit_length` using the provided RNG.
     ///
+    /// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
+    ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
     fn prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self;
 
     /// Returns a random safe prime (that is, such that `(n - 1) / 2` is also prime)
     /// of size `bit_length` using the provided RNG.
+    ///
+    /// Panics if `bit_length` is less than 3, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
     fn safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self;


### PR DESCRIPTION
- When looking for safe primes only check numbers == 3 mod 4 (~2x speedup)
- Handle various corner cases in `Sieve`
- Add a benchmark for `safe_prime()`
- Add a bunch of tests to bump coverage