### PR TITLE
Bounded MR test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `sieve_once()` was removed ([#22]).
 - `MillerRabin::new()` and `test_random_base()` will panic if the input is invalid. ([#22])
 - `MillerRabin::check()` renamed to `test()`. ([#22])
+- Prime-generating function take `Option<usize>` instead of `usize`, where `None` means the full size of the `Uint`. ([#19])
 
 
 ### Added
@@ -22,8 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Some mistakes in the description of Lucas checks (the logic itself was fine). ([#20])
 - Major performance increase across the board due to better sieving (especially for random safe prime finding). ([#22])
+- Performance increase for the cases when the bit size of the generated prime is smaller than that of the containing `Uint`. ([#19])
 
 
+[#19]: https://github.com/nucypher/rust-umbral/pull/19
 [#20]: https://github.com/nucypher/rust-umbral/pull/20
 [#22]: https://github.com/nucypher/rust-umbral/pull/22
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -227,6 +227,28 @@ fn bench_presets(c: &mut Criterion) {
     });
 
     group.finish();
+
+    // A separate group for bounded tests, to make it easier to run them separately.
+    let mut group = c.benchmark_group("Presets (bounded)");
+
+    let mut rng = make_rng();
+    group.bench_function("(U128) Random safe prime", |b| {
+        b.iter(|| safe_prime_with_rng::<{ nlimbs!(128) }>(&mut rng, 128))
+    });
+
+    // The performance should scale with the prime size, not with the Uint size.
+    // So we should strive for this test's result to be as close as possible
+    // to that of the previous one and as far away as possible from the next one.
+    group.bench_function("(U256) Random 128 bit safe prime", |b| {
+        b.iter(|| safe_prime_with_rng::<{ nlimbs!(256) }>(&mut rng, 128))
+    });
+
+    // The upper bound for the previous test.
+    group.bench_function("(U256) Random 256 bit safe prime", |b| {
+        b.iter(|| safe_prime_with_rng::<{ nlimbs!(256) }>(&mut rng, 256))
+    });
+
+    group.finish();
 }
 
 #[cfg(feature = "tests-gmp")]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -207,23 +207,23 @@ fn bench_presets(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random prime", |b| {
-        b.iter(|| prime_with_rng::<{ nlimbs!(128) }>(&mut rng, 128))
+        b.iter(|| prime_with_rng::<{ nlimbs!(128) }>(&mut rng, None))
     });
 
     let mut rng = make_rng();
     group.bench_function("(U1024) Random prime", |b| {
-        b.iter(|| prime_with_rng::<{ nlimbs!(1024) }>(&mut rng, 1024))
+        b.iter(|| prime_with_rng::<{ nlimbs!(1024) }>(&mut rng, None))
     });
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random safe prime", |b| {
-        b.iter(|| safe_prime_with_rng::<{ nlimbs!(128) }>(&mut rng, 128))
+        b.iter(|| safe_prime_with_rng::<{ nlimbs!(128) }>(&mut rng, None))
     });
 
     group.sample_size(20);
     let mut rng = make_rng();
     group.bench_function("(U1024) Random safe prime", |b| {
-        b.iter(|| safe_prime_with_rng::<{ nlimbs!(1024) }>(&mut rng, 1024))
+        b.iter(|| safe_prime_with_rng::<{ nlimbs!(1024) }>(&mut rng, None))
     });
 
     group.finish();
@@ -233,19 +233,19 @@ fn bench_presets(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random safe prime", |b| {
-        b.iter(|| safe_prime_with_rng::<{ nlimbs!(128) }>(&mut rng, 128))
+        b.iter(|| safe_prime_with_rng::<{ nlimbs!(128) }>(&mut rng, None))
     });
 
     // The performance should scale with the prime size, not with the Uint size.
     // So we should strive for this test's result to be as close as possible
     // to that of the previous one and as far away as possible from the next one.
     group.bench_function("(U256) Random 128 bit safe prime", |b| {
-        b.iter(|| safe_prime_with_rng::<{ nlimbs!(256) }>(&mut rng, 128))
+        b.iter(|| safe_prime_with_rng::<{ nlimbs!(256) }>(&mut rng, Some(128)))
     });
 
     // The upper bound for the previous test.
     group.bench_function("(U256) Random 256 bit safe prime", |b| {
-        b.iter(|| safe_prime_with_rng::<{ nlimbs!(256) }>(&mut rng, 256))
+        b.iter(|| safe_prime_with_rng::<{ nlimbs!(256) }>(&mut rng, None))
     });
 
     group.finish();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -7,19 +7,21 @@ use crate::{is_prime_with_rng, is_safe_prime_with_rng, prime_with_rng, safe_prim
 /// and primality checking, wrapping the standalone functions ([`is_prime_with_rng`] etc).
 pub trait RandomPrimeWithRng {
     /// Returns a random prime of size `bit_length` using the provided RNG.
+    /// If `bit_length` is `None`, the full size of `Uint<L>` is used.
     ///
     /// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self;
+    fn prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<usize>) -> Self;
 
     /// Returns a random safe prime (that is, such that `(n - 1) / 2` is also prime)
     /// of size `bit_length` using the provided RNG.
+    /// If `bit_length` is `None`, the full size of `Uint<L>` is used.
     ///
     /// Panics if `bit_length` is less than 3, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self;
+    fn safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<usize>) -> Self;
 
     /// Checks probabilistically if the given number is prime using the provided RNG.
     ///
@@ -33,10 +35,10 @@ pub trait RandomPrimeWithRng {
 }
 
 impl<const L: usize> RandomPrimeWithRng for Uint<L> {
-    fn prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self {
+    fn prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<usize>) -> Self {
         prime_with_rng(rng, bit_length)
     }
-    fn safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self {
+    fn safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<usize>) -> Self {
         safe_prime_with_rng(rng, bit_length)
     }
     fn is_prime_with_rng(&self, rng: &mut impl CryptoRngCore) -> bool {
@@ -62,7 +64,7 @@ mod tests {
         assert!(!U64::from(13u32).is_safe_prime_with_rng(&mut OsRng));
         assert!(U64::from(11u32).is_safe_prime_with_rng(&mut OsRng));
 
-        assert!(U64::prime_with_rng(&mut OsRng, 10).is_prime_with_rng(&mut OsRng));
-        assert!(U64::safe_prime_with_rng(&mut OsRng, 10).is_safe_prime_with_rng(&mut OsRng));
+        assert!(U64::prime_with_rng(&mut OsRng, Some(10)).is_prime_with_rng(&mut OsRng));
+        assert!(U64::safe_prime_with_rng(&mut OsRng, Some(10)).is_safe_prime_with_rng(&mut OsRng));
     }
 }


### PR DESCRIPTION
- Use bounded exponentiation in the MR test taking the bit size of the given candidate.
- Take `Option<usize>` in random prime generation functions, to avoid repetition of the size in most cases (where it is equal to the Uint size) 

MR is the first check that's being run after the sieve, so this can noticeably increase the performance. For example, for the case of `U256`  and a 128 bit bound the speedup of `safe_prime()` is 3.5x (but still 3x slower than U128 with 128 bits).

An example use case: in CGGMP21 scheme, the selected primes `p`, `q` for the Paillier encryption must be big enough for `p * q` to cover the range of squared secp256k1 scalars. This means that `bits(p * q) > 512`. Naturally, for testing purposes one would go with the minimum size, so 257-bit primes and `U320` type. 

Theoretically, the bound can be used in the Lucas test as well, but it only operates with Montgomery multiplication. The performance dependance in `pow_bounded_exp()` is fine-grained enough for the position of the bound within one limb to matter (namely, the step is equal to the window size - 4 bits), but it is not the case for multiplication (whose performance changes with every added limb). If one knows that some limb is not going to be used it is probably easier to just use a different `Uint` type. One can argue though that having a bound in Montgomery multiplication allows for using a single type (e.g. `U2048`) for tests and production, only changing the size bound, without much loss of performance. That would greatly simplify the code. Adding bounds to the Lucas test would require support for bounded Montgomery operations in `crypto_bigint`. 
