### PR TITLE
Sieving improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [0.3.0] - In development
+
+### Changed
+
+- `sieve_once()` was removed ([#22]).
+- `MillerRabin::new()` and `test_random_base()` will panic if the input is invalid. ([#22])
+
 
 ### Added
 
@@ -14,9 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Some mistakes in the description of Lucas checks (the logic itself was fine). ([#20])
+- Major performance increase across the board due to better sieving (especially for random safe prime finding). ([#22])
 
 
 [#20]: https://github.com/nucypher/rust-umbral/pull/20
+[#22]: https://github.com/nucypher/rust-umbral/pull/22
 
 
 ## [0.2.0] - 2023-03-06
@@ -52,6 +60,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Initial release.
 
 
-[Unreleased]: https://github.com/entropyxyz/crypto-primes/compare/v0.2.0...HEAD
 [0.1.0]: https://github.com/nucypher/rust-umbral/releases/tag/v0.1.0
 [0.2.0]: https://github.com/nucypher/rust-umbral/releases/tag/v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `sieve_once()` was removed ([#22]).
 - `MillerRabin::new()` and `test_random_base()` will panic if the input is invalid. ([#22])
+- `MillerRabin::check()` renamed to `test()`. ([#22])
 
 
 ### Added

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,94 +1,169 @@
-use criterion::{
-    criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, Criterion,
-};
-use crypto_bigint::{U1024, U128};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use crypto_bigint::{nlimbs, Uint, U1024};
 use rand_chacha::ChaCha8Rng;
-use rand_core::{OsRng, SeedableRng};
+use rand_core::{CryptoRngCore, OsRng, SeedableRng};
+
+#[cfg(feature = "tests-gmp")]
+use rug::{integer::Order, Integer};
+
+#[cfg(feature = "tests-openssl")]
+use openssl::bn::BigNum;
 
 use crypto_primes::{
     hazmat::{
         lucas_test, random_odd_uint, AStarBase, BruteForceBase, LucasCheck, MillerRabin,
         SelfridgeBase, Sieve,
     },
-    safe_prime_with_rng,
+    is_prime_with_rng, is_safe_prime_with_rng, prime_with_rng, safe_prime_with_rng,
 };
 
-fn bench_sieve<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let start: U1024 = random_odd_uint(&mut OsRng, 1024);
-    group.bench_function("(U1024) Sieve, 1000 samples", |b| {
-        b.iter(|| Sieve::new(&start, 1024, false).take(1000).for_each(drop))
+fn make_rng() -> ChaCha8Rng {
+    ChaCha8Rng::from_seed(*b"01234567890123456789012345678901")
+}
+
+fn make_sieve<const L: usize>(rng: &mut impl CryptoRngCore) -> Sieve<L> {
+    let start: Uint<L> = random_odd_uint(rng, Uint::<L>::BITS);
+    Sieve::new(&start, Uint::<L>::BITS, false)
+}
+
+fn make_presieved_num<const L: usize>(rng: &mut impl CryptoRngCore) -> Uint<L> {
+    let mut sieve = make_sieve(rng);
+    sieve.next().unwrap()
+}
+
+fn bench_sieve(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Sieve");
+
+    group.bench_function("(U128) random start", |b| {
+        b.iter(|| random_odd_uint::<{ nlimbs!(128) }>(&mut OsRng, 128))
+    });
+
+    group.bench_function("(U128) creation", |b| {
+        b.iter_batched(
+            || random_odd_uint::<{ nlimbs!(128) }>(&mut OsRng, 128),
+            |start| Sieve::new(&start, 128, false),
+            BatchSize::SmallInput,
+        )
+    });
+
+    // 5 is the average number of pre-sieved samples we need to take before we encounter a prime
+    group.bench_function("(U128) 5 samples", |b| {
+        b.iter_batched(
+            || make_sieve::<{ nlimbs!(128) }>(&mut OsRng),
+            |sieve| sieve.take(5).for_each(drop),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("(U1024) random start", |b| {
+        b.iter(|| random_odd_uint::<{ nlimbs!(1024) }>(&mut OsRng, 1024))
+    });
+
+    group.bench_function("(U1024) creation", |b| {
+        b.iter_batched(
+            || random_odd_uint::<{ nlimbs!(1024) }>(&mut OsRng, 1024),
+            |start| Sieve::new(&start, 1024, false),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("(U1024) 5 samples", |b| {
+        b.iter_batched(
+            || make_sieve::<{ nlimbs!(1024) }>(&mut OsRng),
+            |sieve| sieve.take(5).for_each(drop),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.finish()
+}
+
+fn bench_miller_rabin(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Miller-Rabin");
+
+    group.bench_function("(U128) creation", |b| {
+        b.iter_batched(
+            || random_odd_uint::<{ nlimbs!(128) }>(&mut OsRng, 128),
+            |start| MillerRabin::new(&start),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("(U128) random base test (pre-sieved)", |b| {
+        b.iter_batched(
+            || MillerRabin::new(&make_presieved_num::<{ nlimbs!(128) }>(&mut OsRng)),
+            |mr| mr.test_random_base(&mut OsRng),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("(U1024) creation", |b| {
+        b.iter_batched(
+            || random_odd_uint::<{ nlimbs!(1024) }>(&mut OsRng, 1024),
+            |start| MillerRabin::new(&start),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("(U1024) random base test (pre-sieved)", |b| {
+        b.iter_batched(
+            || MillerRabin::new(&make_presieved_num::<{ nlimbs!(1024) }>(&mut OsRng)),
+            |mr| mr.test_random_base(&mut OsRng),
+            BatchSize::SmallInput,
+        )
     });
 }
 
-fn bench_miller_rabin<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let start: U1024 = random_odd_uint(&mut OsRng, 1024);
-    group.bench_function("(U1024) Miller-Rabin creation", |b| {
-        b.iter(|| {
-            MillerRabin::new(&start);
-        })
+fn bench_lucas(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Lucas");
+
+    let mut rng = make_rng();
+    group.bench_function("(U128) Selfridge base, strong check (pre-sieved)", |b| {
+        b.iter_batched(
+            || make_presieved_num::<{ nlimbs!(128) }>(&mut rng),
+            |n| lucas_test(&n, SelfridgeBase, LucasCheck::Strong),
+            BatchSize::SmallInput,
+        )
     });
 
-    let start: U1024 = random_odd_uint(&mut OsRng, 1024);
-    let mut sieve = Sieve::new(&start, 1024, false);
-    group.bench_function(
-        "(U1024) Sieve + Miller-Rabin creation + random base check",
-        |b| {
-            b.iter(|| {
-                let mr = MillerRabin::new(&sieve.next().unwrap());
-                mr.test_random_base(&mut OsRng);
-            })
-        },
-    );
-}
-
-fn bench_lucas<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
-
-    let start: U1024 = random_odd_uint(&mut rng, 1024);
-    let mut sieve = Sieve::new(&start, 1024, false);
-    group.bench_function(
-        "(U1024) Sieve + Lucas test (Selfridge base, strong check)",
-        |b| {
-            b.iter(|| {
-                lucas_test(&sieve.next().unwrap(), SelfridgeBase, LucasCheck::Strong);
-            })
-        },
-    );
-
-    let mut sieve = Sieve::new(&start, 1024, false);
-    group.bench_function("(U1024) Sieve + Lucas test (A* base, Lucas-V check)", |b| {
-        b.iter(|| {
-            lucas_test(&sieve.next().unwrap(), AStarBase, LucasCheck::LucasV);
-        })
+    let mut rng = make_rng();
+    group.bench_function("(U1024) Selfridge base, strong check (pre-sieved)", |b| {
+        b.iter_batched(
+            || make_presieved_num::<{ nlimbs!(1024) }>(&mut rng),
+            |n| lucas_test(&n, SelfridgeBase, LucasCheck::Strong),
+            BatchSize::SmallInput,
+        )
     });
 
-    let mut sieve = Sieve::new(&start, 1024, false);
+    let mut rng = make_rng();
+    group.bench_function("(U1024) A* base, Lucas-V check (pre-sieved)", |b| {
+        b.iter_batched(
+            || make_presieved_num::<{ nlimbs!(1024) }>(&mut rng),
+            |n| lucas_test(&n, AStarBase, LucasCheck::LucasV),
+            BatchSize::SmallInput,
+        )
+    });
+
+    let mut rng = make_rng();
     group.bench_function(
-        "(U1024) Sieve + Lucas test (brute force base, almost extra strong)",
+        "(U1024) brute force base, almost extra strong (pre-sieved)",
         |b| {
-            b.iter(|| {
-                lucas_test(
-                    &sieve.next().unwrap(),
-                    BruteForceBase,
-                    LucasCheck::AlmostExtraStrong,
-                );
-            })
+            b.iter_batched(
+                || make_presieved_num::<{ nlimbs!(1024) }>(&mut rng),
+                |n| lucas_test(&n, BruteForceBase, LucasCheck::AlmostExtraStrong),
+                BatchSize::SmallInput,
+            )
         },
     );
 
-    let mut sieve = Sieve::new(&start, 1024, false);
-    group.bench_function(
-        "(U1024) Sieve + Lucas test (brute force base, extra strong)",
-        |b| {
-            b.iter(|| {
-                lucas_test(
-                    &sieve.next().unwrap(),
-                    BruteForceBase,
-                    LucasCheck::ExtraStrong,
-                );
-            })
-        },
-    );
+    let mut rng = make_rng();
+    group.bench_function("(U1024) brute force base, extra strong (pre-sieved)", |b| {
+        b.iter_batched(
+            || make_presieved_num::<{ nlimbs!(1024) }>(&mut rng),
+            |n| lucas_test(&n, BruteForceBase, LucasCheck::ExtraStrong),
+            BatchSize::SmallInput,
+        )
+    });
 
     // A number triggering a slow path through the Lucas test, invoking all the available checks:
     // - U_{d} checked, but is not 0
@@ -102,35 +177,151 @@ fn bench_lucas<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         "7F870924041DFA13EE5F5541C1BF96CA679EFAE2C96F5F4E9DF6007185198F5F"
     ]);
 
-    group.bench_function("(U1024) Lucas test (Selfridge base), slow path", |b| {
+    group.bench_function("(U1024) Selfridge base, strong check, slow path", |b| {
         b.iter(|| {
             lucas_test(&slow_path, SelfridgeBase, LucasCheck::Strong);
         })
     });
-}
 
-fn bench_primality_tests(c: &mut Criterion) {
-    let mut group = c.benchmark_group("primality tests");
-    bench_sieve(&mut group);
-    bench_miller_rabin(&mut group);
-    bench_lucas(&mut group);
     group.finish();
 }
 
-fn bench_presets<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    group.bench_function("(U128) Random safe prime", |b| {
-        b.iter(|| {
-            let p: U128 = safe_prime_with_rng(&mut OsRng, 128);
-            p
-        })
+fn bench_presets(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Presets");
+
+    group.bench_function("(U128) Prime test", |b| {
+        b.iter_batched(
+            || random_odd_uint::<{ nlimbs!(128) }>(&mut OsRng, 128),
+            |num| is_prime_with_rng(&mut OsRng, &num),
+            BatchSize::SmallInput,
+        )
     });
-}
 
-fn bench_prime_generation(c: &mut Criterion) {
-    let mut group = c.benchmark_group("prime numbers generation");
-    bench_presets(&mut group);
+    group.bench_function("(U128) Safe prime test", |b| {
+        b.iter_batched(
+            || random_odd_uint::<{ nlimbs!(128) }>(&mut OsRng, 128),
+            |num| is_safe_prime_with_rng(&mut OsRng, &num),
+            BatchSize::SmallInput,
+        )
+    });
+
+    let mut rng = make_rng();
+    group.bench_function("(U128) Random prime", |b| {
+        b.iter(|| prime_with_rng::<{ nlimbs!(128) }>(&mut rng, 128))
+    });
+
+    let mut rng = make_rng();
+    group.bench_function("(U1024) Random prime", |b| {
+        b.iter(|| prime_with_rng::<{ nlimbs!(1024) }>(&mut rng, 1024))
+    });
+
+    let mut rng = make_rng();
+    group.bench_function("(U128) Random safe prime", |b| {
+        b.iter(|| safe_prime_with_rng::<{ nlimbs!(128) }>(&mut rng, 128))
+    });
+
+    group.sample_size(20);
+    let mut rng = make_rng();
+    group.bench_function("(U1024) Random safe prime", |b| {
+        b.iter(|| safe_prime_with_rng::<{ nlimbs!(1024) }>(&mut rng, 1024))
+    });
+
     group.finish();
 }
 
-criterion_group!(benches, bench_primality_tests, bench_prime_generation);
+#[cfg(feature = "tests-gmp")]
+fn bench_gmp(c: &mut Criterion) {
+    let mut group = c.benchmark_group("GMP");
+
+    fn random<const L: usize>(rng: &mut impl CryptoRngCore) -> Integer {
+        let num: Uint<L> = random_odd_uint(rng, Uint::<L>::BITS);
+        Integer::from_digits(num.as_words(), Order::Lsf)
+    }
+
+    group.bench_function("(U128) Random prime", |b| {
+        b.iter_batched(
+            || random::<{ nlimbs!(128) }>(&mut OsRng),
+            |n| n.next_prime(),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("(U1024) Random prime", |b| {
+        b.iter_batched(
+            || random::<{ nlimbs!(1024) }>(&mut OsRng),
+            |n| n.next_prime(),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.finish();
+}
+
+#[cfg(not(feature = "tests-gmp"))]
+fn bench_gmp(_c: &mut Criterion) {}
+
+#[cfg(feature = "tests-openssl")]
+fn bench_openssl(c: &mut Criterion) {
+    let mut group = c.benchmark_group("OpenSSL");
+
+    group.bench_function("(U128) Random prime", |b| {
+        b.iter_batched(
+            || BigNum::new().unwrap(),
+            |p| {
+                let mut p = p;
+                p.generate_prime(128, false, None, None).unwrap()
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("(U1024) Random prime", |b| {
+        b.iter_batched(
+            || BigNum::new().unwrap(),
+            |p| {
+                let mut p = p;
+                p.generate_prime(1024, false, None, None).unwrap()
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("(U128) Random safe prime", |b| {
+        b.iter_batched(
+            || BigNum::new().unwrap(),
+            |p| {
+                let mut p = p;
+                p.generate_prime(128, true, None, None).unwrap()
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.sample_size(20);
+    group.bench_function("(U1024) Random safe prime", |b| {
+        b.iter_batched(
+            || BigNum::new().unwrap(),
+            |p| {
+                let mut p = p;
+                p.generate_prime(1024, true, None, None).unwrap()
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.finish();
+}
+
+#[cfg(not(feature = "tests-openssl"))]
+fn bench_openssl(_c: &mut Criterion) {}
+
+criterion_group!(
+    benches,
+    bench_sieve,
+    bench_miller_rabin,
+    bench_lucas,
+    bench_presets,
+    bench_gmp,
+    bench_openssl,
+);
 criterion_main!(benches);

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -14,7 +14,7 @@ mod sieve;
 
 pub use lucas::{lucas_test, AStarBase, BruteForceBase, LucasBase, LucasCheck, SelfridgeBase};
 pub use miller_rabin::MillerRabin;
-pub use sieve::{random_odd_uint, sieve_once, Sieve};
+pub use sieve::{random_odd_uint, Sieve};
 
 /// Possible results of various primality tests.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -52,4 +52,11 @@ mod tests {
         assert!(Primality::Prime != Primality::ProbablyPrime);
         assert_eq!(Primality::Prime.clone(), Primality::Prime);
     }
+
+    #[test]
+    fn primality_to_bool() {
+        assert!(Primality::Prime.is_probably_prime());
+        assert!(Primality::ProbablyPrime.is_probably_prime());
+        assert!(!Primality::Composite.is_probably_prime());
+    }
 }

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -56,7 +56,7 @@ impl<const L: usize> MillerRabin<L> {
     }
 
     /// Perform a Miller-Rabin check with a given base.
-    pub fn check(&self, base: &Uint<L>) -> Primality {
+    pub fn test(&self, base: &Uint<L>) -> Primality {
         // TODO: it may be faster to first check that gcd(base, candidate) == 1,
         // otherwise we can return `Composite` right away.
 
@@ -79,7 +79,7 @@ impl<const L: usize> MillerRabin<L> {
 
     /// Perform a Miller-Rabin check with base 2.
     pub fn test_base_two(&self) -> Primality {
-        self.check(&Uint::<L>::from(2u32))
+        self.test(&Uint::<L>::from(2u32))
     }
 
     /// Perform a Miller-Rabin check with a random base (in the range `[3, candidate-2]`)
@@ -98,7 +98,7 @@ impl<const L: usize> MillerRabin<L> {
         let range_nonzero = NonZero::new(range).unwrap();
         let random =
             Uint::<L>::random_mod(rng, &range_nonzero).wrapping_add(&Uint::<L>::from(3u32));
-        self.check(&random)
+        self.test(&random)
     }
 }
 
@@ -188,10 +188,8 @@ mod tests {
             let mr = MillerRabin::new(&num);
 
             // Trivial tests, must always be true.
-            assert!(mr.check(&1u32.into()).is_probably_prime());
-            assert!(mr
-                .check(&num.wrapping_sub(&1u32.into()))
-                .is_probably_prime());
+            assert!(mr.test(&1u32.into()).is_probably_prime());
+            assert!(mr.test(&num.wrapping_sub(&1u32.into())).is_probably_prime());
         }
     }
 
@@ -246,10 +244,10 @@ mod tests {
 
         // It is known to pass MR tests for all prime bases <307
         assert!(mr.test_base_two().is_probably_prime());
-        assert!(mr.check(&U1536::from(293u64)).is_probably_prime());
+        assert!(mr.test(&U1536::from(293u64)).is_probably_prime());
 
         // A test with base 307 correctly reports the number as composite.
-        assert!(!mr.check(&U1536::from(307u64)).is_probably_prime());
+        assert!(!mr.test(&U1536::from(307u64)).is_probably_prime());
     }
 
     fn test_large_primes<const L: usize>(nums: &[Uint<L>]) {

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -109,7 +109,7 @@ mod tests {
 
     use crypto_bigint::{Uint, U1024, U128, U1536, U64};
     use rand_chacha::ChaCha8Rng;
-    use rand_core::{CryptoRngCore, SeedableRng};
+    use rand_core::{CryptoRngCore, OsRng, SeedableRng};
 
     #[cfg(feature = "tests-exhaustive")]
     use num_prime::nt_funcs::is_prime64;
@@ -122,6 +122,21 @@ mod tests {
         let mr = MillerRabin::new(&U64::ONE);
         assert!(format!("{mr:?}").starts_with("MillerRabin"));
         assert_eq!(mr.clone(), mr);
+    }
+
+    #[test]
+    #[should_panic(expected = "`candidate` must be odd.")]
+    fn parity_check() {
+        let _mr = MillerRabin::new(&U64::from(10u32));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "No suitable random base possible when `candidate == 3`; use the base 2 test."
+    )]
+    fn random_base_range_check() {
+        let mr = MillerRabin::new(&U64::from(3u32));
+        mr.test_random_base(&mut OsRng);
     }
 
     fn is_spsp(num: u32) -> bool {

--- a/src/hazmat/precomputed.rs
+++ b/src/hazmat/precomputed.rs
@@ -1,8 +1,12 @@
+use crypto_bigint::{Limb, Reciprocal, Word};
+
 /// The type that fits any small prime from the table.
 pub(crate) type SmallPrime = u16;
 
+const SMALL_PRIMES_SIZE: usize = 2047;
+
 /// The list of 2nd to 2048th primes (The 1st one, 2, is not included).
-pub(crate) const SMALL_PRIMES: [SmallPrime; 2047] = [
+pub(crate) const SMALL_PRIMES: [SmallPrime; SMALL_PRIMES_SIZE] = [
     3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97,
     101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193,
     197, 199, 211, 223, 227, 229, 233, 239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307,
@@ -142,3 +146,15 @@ pub(crate) const SMALL_PRIMES: [SmallPrime; 2047] = [
     17599, 17609, 17623, 17627, 17657, 17659, 17669, 17681, 17683, 17707, 17713, 17729, 17737,
     17747, 17749, 17761, 17783, 17789, 17791, 17807, 17827, 17837, 17839, 17851, 17863,
 ];
+
+const fn create_reciprocals() -> [Reciprocal; SMALL_PRIMES_SIZE] {
+    let mut arr = [Reciprocal::default(); SMALL_PRIMES_SIZE];
+    let mut i = 0;
+    while i < SMALL_PRIMES_SIZE {
+        arr[i] = Reciprocal::ct_new(Limb(SMALL_PRIMES[i] as Word)).0;
+        i += 1;
+    }
+    arr
+}
+
+pub(crate) const RECIPROCALS: [Reciprocal; SMALL_PRIMES_SIZE] = create_reciprocals();

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -7,7 +7,7 @@ use crypto_bigint::{Integer, Limb, NonZero, Random, Uint, Zero};
 use rand_core::CryptoRngCore;
 
 use crate::hazmat::{
-    precomputed::{SmallPrime, SMALL_PRIMES},
+    precomputed::{SmallPrime, RECIPROCALS, SMALL_PRIMES},
     Primality,
 };
 
@@ -151,10 +151,8 @@ impl<const L: usize> Sieve<L> {
         self.incr = 0;
 
         // Re-calculate residues.
-        for (i, small_prime) in SMALL_PRIMES.iter().enumerate().take(self.residues.len()) {
-            let (_quo, rem) = self
-                .base
-                .div_rem_limb(NonZero::new(Limb::from(*small_prime)).unwrap());
+        for (i, rec) in RECIPROCALS.iter().enumerate().take(self.residues.len()) {
+            let (_quo, rem) = self.base.ct_div_rem_limb_with_reciprocal(rec);
             self.residues[i] = rem.0 as SmallPrime;
         }
 

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -5,7 +5,7 @@ use rand_core::CryptoRngCore;
 use rand_core::OsRng;
 
 use crate::hazmat::{
-    lucas_test, random_odd_uint, sieve_once, LucasCheck, MillerRabin, SelfridgeBase, Sieve,
+    lucas_test, random_odd_uint, LucasCheck, MillerRabin, Primality, SelfridgeBase, Sieve,
 };
 
 /// Returns a random prime of size `bit_length` using [`OsRng`] as the RNG.
@@ -56,7 +56,7 @@ pub fn prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, bit_length: 
         let start: Uint<L> = random_odd_uint(rng, bit_length);
         let sieve = Sieve::new(&start, bit_length, false);
         for num in sieve {
-            if _is_prime_with_rng(rng, &num) {
+            if is_prime_with_rng(rng, &num) {
                 return num;
             }
         }
@@ -80,13 +80,9 @@ pub fn safe_prime_with_rng<const L: usize>(
         let start: Uint<L> = random_odd_uint(rng, bit_length);
         let sieve = Sieve::new(&start, bit_length, true);
         for num in sieve {
-            if !_is_prime_with_rng(rng, &num) {
-                continue;
+            if is_safe_prime_with_rng(rng, &num) {
+                return num;
             }
-            if !is_prime_with_rng(rng, &(num >> 1)) {
-                continue;
-            }
-            return num;
         }
     }
 }
@@ -94,14 +90,13 @@ pub fn safe_prime_with_rng<const L: usize>(
 /// Checks probabilistically if the given number is prime using the provided RNG.
 ///
 /// Performed checks:
-/// - Trial division by a number of small primes;
 /// - Miller-Rabin check with base 2;
 /// - Strong Lucas check with Selfridge base (a.k.a. Baillie method A);
 /// - Miller-Rabin check with a random base.
 ///
 /// See [`MillerRabin`] and [`lucas_test`] for more details about the checks.
 ///
-/// The second and the third checks constitute the Baillie-PSW primality test[^Baillie1980];
+/// The first two checks constitute the Baillie-PSW primality test[^Baillie1980];
 /// the third one is a precaution that follows the approach of GMP (as of v6.2.1).
 /// At the moment of the writing there are no known composites passing
 /// the Baillie-PSW test[^Baillie2021];
@@ -118,9 +113,13 @@ pub fn safe_prime_with_rng<const L: usize>(
 ///       Math. Comp. 90 1931-1955 (2021),
 ///       DOI: [10.1090/mcom/3616](https://doi.org/10.1090/mcom/3616)
 pub fn is_prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, num: &Uint<L>) -> bool {
-    if let Some(primality) = sieve_once(num) {
-        return primality.is_probably_prime();
+    if num == &Uint::<L>::from(2u32) {
+        return true;
     }
+    if num.is_even().into() {
+        return false;
+    }
+
     _is_prime_with_rng(rng, num)
 }
 
@@ -138,38 +137,35 @@ pub fn is_safe_prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, num:
         return false;
     }
 
-    if let Some(primality) = sieve_once(num) {
-        // If sieving returns a definite conclusion about `num`, use it.
-        if !primality.is_probably_prime() {
-            return false;
-        }
-    } else {
-        // Otherwise run the rest of the checks.
-        if !_is_prime_with_rng(rng, num) {
-            return false;
-        }
-    };
-
-    if !is_prime_with_rng(rng, &(num >> 1)) {
-        return false;
-    }
-
-    true
+    _is_prime_with_rng(rng, num) && _is_prime_with_rng(rng, &(num >> 1))
 }
 
-/// Checks for primality assuming that `num` was already pre-sieved.
+/// Checks for primality assuming that `num` is odd.
 fn _is_prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, num: &Uint<L>) -> bool {
     debug_assert!(bool::from(num.is_odd()));
     let mr = MillerRabin::new(num);
-    if !mr.test_base_two().is_probably_prime() {
-        return false;
+
+    match mr.test_base_two() {
+        Primality::Composite => return false,
+        Primality::Prime => return true,
+        _ => {}
     }
-    if !lucas_test(num, SelfridgeBase, LucasCheck::Strong).is_probably_prime() {
-        return false;
+
+    match lucas_test(num, SelfridgeBase, LucasCheck::Strong) {
+        Primality::Composite => return false,
+        Primality::Prime => return true,
+        _ => {}
     }
-    if !mr.test_random_base(rng).is_probably_prime() {
-        return false;
+
+    // The random base test only makes sense when `num > 3`.
+    if num.bits() > 2 {
+        match mr.test_random_base(rng) {
+            Primality::Composite => return false,
+            Primality::Prime => return true,
+            _ => {}
+        }
     }
+
     true
 }
 

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -145,10 +145,8 @@ fn _is_prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, num: &Uint<L
     debug_assert!(bool::from(num.is_odd()));
     let mr = MillerRabin::new(num);
 
-    match mr.test_base_two() {
-        Primality::Composite => return false,
-        Primality::Prime => return true,
-        _ => {}
+    if !mr.test_base_two().is_probably_prime() {
+        return false;
     }
 
     match lucas_test(num, SelfridgeBase, LucasCheck::Strong) {
@@ -158,12 +156,8 @@ fn _is_prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, num: &Uint<L
     }
 
     // The random base test only makes sense when `num > 3`.
-    if num.bits() > 2 {
-        match mr.test_random_base(rng) {
-            Primality::Composite => return false,
-            Primality::Prime => return true,
-            _ => {}
-        }
+    if num.bits() > 2 && !mr.test_random_base(rng).is_probably_prime() {
+        return false;
     }
 
     true


### PR DESCRIPTION
Public changes:
- Precompute reciprocals for sieving (performance increase)
- Perform combined sieving (check the residues of both `n` and `n/2`) when searching for safe primes (a dramatic performance increase)
- Don't run sieving in `is_prime()` etc - BPSW is enough, and sieving only slows the test down.
- `sieve_once()` is removed.

Other changes:
- Removed `decompose()` since we now have `trailing_zeros()` available
- Organized existing benchmarks to better isolate the components
- Added GMP and OpenSSL benchmarks