### PR TITLE
Use verbs instead of nouns for prime-generation functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MillerRabin::new()` and `test_random_base()` will panic if the input is invalid. ([#22])
 - `MillerRabin::check()` renamed to `test()`. ([#22])
 - Prime-generating function take `Option<usize>` instead of `usize`, where `None` means the full size of the `Uint`. ([#19])
+- Renamed `prime()` to `generate_prime()`, `safe_prime()` to `generate_safe_prime()`, `prime_with_rng()` to `generate_prime_with_rng()`, `safe_prime_with_rng()` to `generate_safe_prime_with_rng()`. ([#24])
 
 
 ### Added
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#19]: https://github.com/nucypher/rust-umbral/pull/19
 [#20]: https://github.com/nucypher/rust-umbral/pull/20
 [#22]: https://github.com/nucypher/rust-umbral/pull/22
+[#24]: https://github.com/nucypher/rust-umbral/pull/24
 
 
 ## [0.2.0] - 2023-03-06

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -10,11 +10,12 @@ use rug::{integer::Order, Integer};
 use openssl::bn::BigNum;
 
 use crypto_primes::{
+    generate_prime_with_rng, generate_safe_prime_with_rng,
     hazmat::{
         lucas_test, random_odd_uint, AStarBase, BruteForceBase, LucasCheck, MillerRabin,
         SelfridgeBase, Sieve,
     },
-    is_prime_with_rng, is_safe_prime_with_rng, prime_with_rng, safe_prime_with_rng,
+    is_prime_with_rng, is_safe_prime_with_rng,
 };
 
 fn make_rng() -> ChaCha8Rng {
@@ -207,23 +208,23 @@ fn bench_presets(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random prime", |b| {
-        b.iter(|| prime_with_rng::<{ nlimbs!(128) }>(&mut rng, None))
+        b.iter(|| generate_prime_with_rng::<{ nlimbs!(128) }>(&mut rng, None))
     });
 
     let mut rng = make_rng();
     group.bench_function("(U1024) Random prime", |b| {
-        b.iter(|| prime_with_rng::<{ nlimbs!(1024) }>(&mut rng, None))
+        b.iter(|| generate_prime_with_rng::<{ nlimbs!(1024) }>(&mut rng, None))
     });
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random safe prime", |b| {
-        b.iter(|| safe_prime_with_rng::<{ nlimbs!(128) }>(&mut rng, None))
+        b.iter(|| generate_safe_prime_with_rng::<{ nlimbs!(128) }>(&mut rng, None))
     });
 
     group.sample_size(20);
     let mut rng = make_rng();
     group.bench_function("(U1024) Random safe prime", |b| {
-        b.iter(|| safe_prime_with_rng::<{ nlimbs!(1024) }>(&mut rng, None))
+        b.iter(|| generate_safe_prime_with_rng::<{ nlimbs!(1024) }>(&mut rng, None))
     });
 
     group.finish();
@@ -233,19 +234,19 @@ fn bench_presets(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random safe prime", |b| {
-        b.iter(|| safe_prime_with_rng::<{ nlimbs!(128) }>(&mut rng, None))
+        b.iter(|| generate_safe_prime_with_rng::<{ nlimbs!(128) }>(&mut rng, None))
     });
 
     // The performance should scale with the prime size, not with the Uint size.
     // So we should strive for this test's result to be as close as possible
     // to that of the previous one and as far away as possible from the next one.
     group.bench_function("(U256) Random 128 bit safe prime", |b| {
-        b.iter(|| safe_prime_with_rng::<{ nlimbs!(256) }>(&mut rng, Some(128)))
+        b.iter(|| generate_safe_prime_with_rng::<{ nlimbs!(256) }>(&mut rng, Some(128)))
     });
 
     // The upper bound for the previous test.
     group.bench_function("(U256) Random 256 bit safe prime", |b| {
-        b.iter(|| safe_prime_with_rng::<{ nlimbs!(256) }>(&mut rng, None))
+        b.iter(|| generate_safe_prime_with_rng::<{ nlimbs!(256) }>(&mut rng, None))
     });
 
     group.finish();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,11 @@ pub mod hazmat;
 mod presets;
 mod traits;
 
-pub use presets::{is_prime_with_rng, is_safe_prime_with_rng, prime_with_rng, safe_prime_with_rng};
+pub use presets::{
+    generate_prime_with_rng, generate_safe_prime_with_rng, is_prime_with_rng,
+    is_safe_prime_with_rng,
+};
 pub use traits::RandomPrimeWithRng;
 
 #[cfg(feature = "default-rng")]
-pub use presets::{is_prime, is_safe_prime, prime, safe_prime};
+pub use presets::{generate_prime, generate_safe_prime, is_prime, is_safe_prime};

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,10 @@
 use crypto_bigint::Uint;
 use rand_core::CryptoRngCore;
 
-use crate::{is_prime_with_rng, is_safe_prime_with_rng, prime_with_rng, safe_prime_with_rng};
+use crate::{
+    generate_prime_with_rng, generate_safe_prime_with_rng, is_prime_with_rng,
+    is_safe_prime_with_rng,
+};
 
 /// Provides a generic way to access methods for random prime number generation
 /// and primality checking, wrapping the standalone functions ([`is_prime_with_rng`] etc).
@@ -12,7 +15,7 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<usize>) -> Self;
+    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<usize>) -> Self;
 
     /// Returns a random safe prime (that is, such that `(n - 1) / 2` is also prime)
     /// of size `bit_length` using the provided RNG.
@@ -21,7 +24,10 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 3, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<usize>) -> Self;
+    fn generate_safe_prime_with_rng(
+        rng: &mut impl CryptoRngCore,
+        bit_length: Option<usize>,
+    ) -> Self;
 
     /// Checks probabilistically if the given number is prime using the provided RNG.
     ///
@@ -35,11 +41,14 @@ pub trait RandomPrimeWithRng {
 }
 
 impl<const L: usize> RandomPrimeWithRng for Uint<L> {
-    fn prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<usize>) -> Self {
-        prime_with_rng(rng, bit_length)
+    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<usize>) -> Self {
+        generate_prime_with_rng(rng, bit_length)
     }
-    fn safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<usize>) -> Self {
-        safe_prime_with_rng(rng, bit_length)
+    fn generate_safe_prime_with_rng(
+        rng: &mut impl CryptoRngCore,
+        bit_length: Option<usize>,
+    ) -> Self {
+        generate_safe_prime_with_rng(rng, bit_length)
     }
     fn is_prime_with_rng(&self, rng: &mut impl CryptoRngCore) -> bool {
         is_prime_with_rng(rng, self)
@@ -64,7 +73,8 @@ mod tests {
         assert!(!U64::from(13u32).is_safe_prime_with_rng(&mut OsRng));
         assert!(U64::from(11u32).is_safe_prime_with_rng(&mut OsRng));
 
-        assert!(U64::prime_with_rng(&mut OsRng, Some(10)).is_prime_with_rng(&mut OsRng));
-        assert!(U64::safe_prime_with_rng(&mut OsRng, Some(10)).is_safe_prime_with_rng(&mut OsRng));
+        assert!(U64::generate_prime_with_rng(&mut OsRng, Some(10)).is_prime_with_rng(&mut OsRng));
+        assert!(U64::generate_safe_prime_with_rng(&mut OsRng, Some(10))
+            .is_safe_prime_with_rng(&mut OsRng));
     }
 }


### PR DESCRIPTION
Rename `prime()` to `generate_prime()`, `safe_prime()` to `generate_safe_prime()`, `prime_with_rng()` to `generate_prime_with_rng()`, `safe_prime_with_rng()` to `generate_safe_prime_with_rng()`. Functions should have verb phrase names, and it also makes it easier to search for them