### PR TITLE
NCC audit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `Sieve::new()` now panics when `max_bit_length == 0` (which would lead to incorrect results anyway, so it is not considered a breaking change). ([#26])
+- Default preset now uses A* instead of A base selection method for the Lucas test. This does not change the outcomes, but is implemented as a security recommendation. ([#26])
 
 
 [#26]: https://github.com/nucypher/rust-umbral/pull/26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.1] - Unreleased
+
+### Fixed
+
+- `Sieve::new()` now panics when `max_bit_length == 0` (which would lead to incorrect results anyway, so it is not considered a breaking change). ([#26])
+
+
+[#26]: https://github.com/nucypher/rust-umbral/pull/26
+
+
 ## [0.3.0] - 2023-05-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This library implements prime number generation and primality checking for [`cry
 In particular:
 
 - Generating random primes and safe primes of given bit size;
-- Sieving iterator and one-time trial division by small integers;
+- Sieving iterator;
 - Miller-Rabin test;
 - Strong and extra strong Lucas tests, and Lucas-V test.
 

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -1,7 +1,7 @@
 //! Lucas primality test.
 use crypto_bigint::{
     modular::runtime_mod::{DynResidue, DynResidueParams},
-    Integer, Limb, Uint, Word,
+    CheckedAdd, Integer, Limb, Uint, Word,
 };
 
 use super::{
@@ -187,7 +187,7 @@ fn decompose<const L: usize>(n: &Uint<L>) -> (u32, Uint<L>) {
     }
 
     // This won't overflow since the original `n` was odd, so we right-shifted at least once.
-    (s, n.wrapping_add(&Uint::<L>::ONE))
+    (s, n.checked_add(&Uint::<L>::ONE).expect("Integer overflow"))
 }
 
 /// The checks to perform in the Lucas test.

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -21,7 +21,8 @@ const MAX_ATTEMPTS: u32 = 10000;
 // (~30x for 1024-bit numbers, ~100x for 2048 bit).
 // On the other hand, if `n` is a non-square we expect to find a `D`
 // in just a few attempts on average (an estimate for the Selfridge method
-// can be found in [^1], section 7; for the brute force method it seems to be about the same).
+// can be found in [^Baillie1980], section 7; for the brute force method
+// it seems to be about the same).
 const ATTEMPTS_BEFORE_SQRT: u32 = 30;
 
 /// A method for selecting the base `(P, Q)` for the Lucas primality test.

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -349,7 +349,7 @@ pub fn lucas_test<const L: usize>(
     // Compute d-th element of Lucas sequence (U_d(P, Q), V_d(P, Q)), where:
     //
     // V_0 = 2
-    // U_0 = 1
+    // U_0 = 0
     //
     // U_{2k} = U_k V_k
     // V_{2k} = V_k^2 - 2 Q^k

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -75,10 +75,14 @@ impl<const L: usize> Sieve<L> {
     /// Note that `start` is adjusted to `2`, or the next `1 mod 2` number (`safe_primes = false`);
     /// and `5`, or `3 mod 4` number (`safe_primes = true`).
     ///
-    /// Panics if `max_bit_length` is greater than the size of the target `Uint`.
+    /// Panics if `max_bit_length` is zero or greater than the size of the target `Uint`.
     ///
     /// If `safe_primes` is `true`, both the returned `n` and `n/2` are sieved.
     pub fn new(start: &Uint<L>, max_bit_length: usize, safe_primes: bool) -> Self {
+        if max_bit_length == 0 {
+            panic!("The requested bit length cannot be zero");
+        }
+
         if max_bit_length > Uint::<L>::BITS {
             panic!(
                 "The requested bit length ({}) is larger than the chosen Uint size",
@@ -331,6 +335,12 @@ mod tests {
 
         check_sieve(9, 4, true, &[11]);
         check_sieve(13, 4, true, &[]);
+    }
+
+    #[test]
+    #[should_panic(expected = "The requested bit length cannot be zero")]
+    fn sieve_zero_bits() {
+        let _sieve = Sieve::new(&U64::ONE, 0, false);
     }
 
     #[test]

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -5,7 +5,7 @@ use rand_core::CryptoRngCore;
 use rand_core::OsRng;
 
 use crate::hazmat::{
-    lucas_test, random_odd_uint, LucasCheck, MillerRabin, Primality, SelfridgeBase, Sieve,
+    lucas_test, random_odd_uint, AStarBase, LucasCheck, MillerRabin, Primality, Sieve,
 };
 
 /// Returns a random prime of size `bit_length` using [`OsRng`] as the RNG.
@@ -100,7 +100,7 @@ pub fn generate_safe_prime_with_rng<const L: usize>(
 ///
 /// Performed checks:
 /// - Miller-Rabin check with base 2;
-/// - Strong Lucas check with Selfridge base (a.k.a. Baillie method A);
+/// - Strong Lucas check with A* base (see [`AStarBase`] for details);
 /// - Miller-Rabin check with a random base.
 ///
 /// See [`MillerRabin`] and [`lucas_test`] for more details about the checks.
@@ -158,7 +158,7 @@ fn _is_prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, num: &Uint<L
         return false;
     }
 
-    match lucas_test(num, SelfridgeBase, LucasCheck::Strong) {
+    match lucas_test(num, AStarBase, LucasCheck::Strong) {
         Primality::Composite => return false,
         Primality::Prime => return true,
         _ => {}


### PR DESCRIPTION
- Fixed some comment typos 
- Added a `max_bit_length == 0` check in `Sieve::new()` (NCC-E008526-K2E)
- Replaced `wrapping_add()` with `checked_add()` calls to detect possible contract violations early (NCC-E008526-QTR)
- Removed a check for `a == i32::MIN` in `jacobi_symbol()` (`abs_diff()` handles this case just fine)
- Using A* by default for the Lucas test
