### PR TITLE
Relax the `subtle` version requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.1] - in development
+
+### Fixed
+
+- `subtle` version requirement relaxed to the (implicit) 2.4, instead of technically requiring 2.5 to compile. ([#30])
+
+
+[#30]: https://github.com/nucypher/rust-umbral/pull/30
+
+
 ## [0.4.0] - 2023-06-28
 
 ### Changed

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -187,7 +187,10 @@ fn decompose<const L: usize>(n: &Uint<L>) -> (u32, Uint<L>) {
     }
 
     // This won't overflow since the original `n` was odd, so we right-shifted at least once.
-    (s, n.checked_add(&Uint::<L>::ONE).expect("Integer overflow"))
+    (
+        s,
+        Option::from(n.checked_add(&Uint::<L>::ONE)).expect("Integer overflow"),
+    )
 }
 
 /// The checks to perform in the Lucas test.

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -106,9 +106,10 @@ impl<const L: usize> MillerRabin<L> {
         let range_nonzero = NonZero::new(range).unwrap();
         // This should not overflow as long as `random_mod()` behaves according to the contract
         // (that is, returns a number within the given range).
-        let random = Uint::<L>::random_mod(rng, &range_nonzero)
-            .checked_add(&Uint::<L>::from(3u32))
-            .expect("Integer overflow");
+        let random = Option::from(
+            Uint::<L>::random_mod(rng, &range_nonzero).checked_add(&Uint::<L>::from(3u32)),
+        )
+        .expect("Integer overflow");
         self.test(&random)
     }
 }

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -155,10 +155,8 @@ impl<const L: usize> Sieve<L> {
         // Should not overflow since `incr` is never greater than `incr_limit`,
         // and the latter is chosen such that it doesn't overflow when added to `base`
         // (see the rest of this method).
-        self.base = self
-            .base
-            .checked_add(&self.incr.into())
-            .expect("Integer overflow");
+        self.base =
+            Option::from(self.base.checked_add(&self.incr.into())).expect("Integer overflow");
 
         self.incr = 0;
 
@@ -219,10 +217,8 @@ impl<const L: usize> Sieve<L> {
             // The overflow should never happen here since `incr`
             // is never greater than `incr_limit`, and the latter is chosen such that
             // it does not overflow when added to `base` (see `update_residues()`).
-            let mut num = self
-                .base
-                .checked_add(&self.incr.into())
-                .expect("Integer overflow");
+            let mut num =
+                Option::from(self.base.checked_add(&self.incr.into())).expect("Integer overflow");
             if self.safe_primes {
                 num = (num << 1) | Uint::<L>::ONE;
             }


### PR DESCRIPTION
`CtOption::expect()` was introduced in `subtle` 2.5. `crypto-bigint` 0.5.2 depends on `subtle` 2.4, so this PR changes the uses of `expect` to the API available there instead.
