### PR TITLE
Pin MSRV and the lower bound of some dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+### Changed
+
+- Set and explicit MSRV 1.65 in `Cargo.toml`. ([#31])
+- Set lower bound `openssl = 0.10.39`. ([#31])
+- Set lower bound `rand_core = 0.6.4`. ([#31])
+
+
+[#31]: https://github.com/nucypher/rust-umbral/pull/31
+
+
 ## [0.4.1] - 2023-07-11
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,12 @@ description = "Random prime number generation and primality checking library"
 repository = "https://github.com/entropyxyz/crypto-primes"
 readme = "README.md"
 categories = ["cryptography", "no-std"]
+rust-version = "1.65"
 
 [dependencies]
 crypto-bigint = { version = "0.5.2", default-features = false, features = ["rand_core"] }
-rand_core = { version = "0.6", default-features = false }
-openssl = { version = "0.10", optional = true, features = ["vendored"] }
+rand_core = { version = "0.6.4", default-features = false }
+openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
 rug = { version = "1.18", default-features = false, features = ["integer"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
- pin MSRV to 1.65 in Cargo.toml
- add lower bound `openssl=0.10.39` (compilation fails before that)
- add lower bound `rand_core=0.6.4` (`CryptoRngCore` introduced; the previous `0.6` worked before because `crypto-bigint` had 0.6.4 in the dependencies, but since we're using that trait too, we should also bound it)