### PR TITLE
Further coverage of UintLike

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,13 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.65"
 
 [dependencies]
-# crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint.git", default-features = false, features = ["rand_core", "alloc"], rev = "4bf6932cee08af70d0a05625b540242522cc77f3" }
-crypto-bigint = { path = "../crypto-bigint", default-features = false, features = ["rand_core", "alloc"] }
+crypto-bigint = { git = "https://github.com/xuganyu96/crypto-bigint.git", default-features = false, features = ["rand_core", "alloc"], rev = "9d730ab" }
 rand_core = { version = "0.6.4", default-features = false }
 openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
 rug = { version = "1.18", default-features = false, features = ["integer"], optional = true }
+rand_chacha = "0.3"
 
 [dev-dependencies]
-rand_chacha = "0.3"
 criterion = { version = "0.4", features = ["html_reports"] }
 num-modular = { version = "0.5", features = ["num-bigint"] }
 num-bigint = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.65"
 
 [dependencies]
-crypto-bigint = { git = "https://github.com/xuganyu96/crypto-bigint.git", default-features = false, features = ["rand_core", "alloc"], rev = "9d730ab" }
+crypto-bigint = { git = "https://github.com/xuganyu96/crypto-bigint.git", default-features = false, features = ["rand_core", "alloc"], rev = "f433d38" }
 rand_core = { version = "0.6.4", default-features = false }
 openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
 rug = { version = "1.18", default-features = false, features = ["integer"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.65"
 
 [dependencies]
-crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint.git", default-features = false, features = ["rand_core", "alloc"], rev = "4bf6932cee08af70d0a05625b540242522cc77f3" }
+# crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint.git", default-features = false, features = ["rand_core", "alloc"], rev = "4bf6932cee08af70d0a05625b540242522cc77f3" }
+crypto-bigint = { path = "../crypto-bigint", default-features = false, features = ["rand_core", "alloc"] }
 rand_core = { version = "0.6.4", default-features = false }
 openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
 rug = { version = "1.18", default-features = false, features = ["integer"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.65"
 
 [dependencies]
-crypto-bigint = { version = "0.5.4", default-features = false, features = ["rand_core"] }
+crypto-bigint = { version = "0.6.0-pre.0", default-features = false, features = ["rand_core"] }
 rand_core = { version = "0.6.4", default-features = false }
 openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
 rug = { version = "1.18", default-features = false, features = ["integer"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.65"
 
 [dependencies]
-crypto-bigint = { git = "https://github.com/xuganyu96/crypto-bigint.git", default-features = false, features = ["rand_core", "alloc"], rev = "f433d38" }
+crypto-bigint = { git = "https://github.com/xuganyu96/crypto-bigint.git", default-features = false, features = ["rand_core", "alloc"], branch = "boxed-uintlike-coverage" }
 rand_core = { version = "0.6.4", default-features = false }
 openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
 rug = { version = "1.18", default-features = false, features = ["integer"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.65"
 
 [dependencies]
-crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint", branch = "master", features = ["alloc"] }
+crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint", branch = "master", features = ["alloc", "rand_core" ] }
 rand_core = { version = "0.6.4", default-features = false }
 openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
 rug = { version = "1.18", default-features = false, features = ["integer"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.65"
 
 [dependencies]
-crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint", branch = "master", features = ["alloc", "rand_core" ] }
+crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint.git", default-features = false, features = ["rand_core", "alloc"], rev = "4bf6932cee08af70d0a05625b540242522cc77f3" }
 rand_core = { version = "0.6.4", default-features = false }
 openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
 rug = { version = "1.18", default-features = false, features = ["integer"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.65"
 
 [dependencies]
-crypto-bigint = { version = "0.6.0-pre.0", default-features = false, features = ["rand_core"] }
+crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint", branch = "master", features = ["alloc"] }
 rand_core = { version = "0.6.4", default-features = false }
 openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
 rug = { version = "1.18", default-features = false, features = ["integer"], optional = true }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -222,7 +222,7 @@ fn bench_presets(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("(U1024) Random prime", |b| {
-        b.iter(|| generate_prime_with_rng::<U1024>(&mut rng, 1024, U128::BITS))
+        b.iter(|| generate_prime_with_rng::<U1024>(&mut rng, 1024, U1024::BITS))
     });
 
     let mut rng = make_rng();

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -29,7 +29,7 @@ fn make_sieve<T: UintLike>(
     bits_precision: u32,
 ) -> Sieve<T> {
     let start: T = random_odd_uint(rng, bit_length, bits_precision);
-    return Sieve::new(&start, bit_length, false);
+    return Sieve::new(&start, bit_length, false, bits_precision);
 }
 
 fn make_presieved_num<T: UintLike>(
@@ -51,7 +51,7 @@ fn bench_sieve(c: &mut Criterion) {
     group.bench_function("(U128) creation", |b| {
         b.iter_batched(
             || random_odd_uint(&mut OsRng, 128, U128::BITS),
-            |start| Sieve::<U128>::new(&start, 128, false),
+            |start| Sieve::<U128>::new(&start, 128, false, U128::BITS),
             BatchSize::SmallInput,
         )
     });
@@ -72,7 +72,7 @@ fn bench_sieve(c: &mut Criterion) {
     group.bench_function("(U1024) creation", |b| {
         b.iter_batched(
             || random_odd_uint(&mut OsRng, 1024, U1024::BITS),
-            |start| Sieve::<U1024>::new(&start, 1024, false),
+            |start| Sieve::<U1024>::new(&start, 1024, false, U1024::BITS),
             BatchSize::SmallInput,
         )
     });

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -4,7 +4,7 @@
 //mod gcd;
 //mod jacobi;
 mod lucas;
-//mod miller_rabin;
+mod miller_rabin;
 mod precomputed;
 #[cfg(test)]
 pub(crate) mod primes;
@@ -13,8 +13,8 @@ pub(crate) mod pseudoprimes;
 mod sieve;
 
 pub use lucas::{lucas_test, AStarBase, BruteForceBase, LucasBase, LucasCheck, SelfridgeBase};
-//pub use miller_rabin::MillerRabin;
-//pub use sieve::{random_odd_uint, Sieve};
+pub use miller_rabin::MillerRabin;
+pub use sieve::{random_odd_uint, Sieve};
 
 /// Possible results of various primality tests.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -1,7 +1,7 @@
 //! Components to build your own primality test.
 //! Handle with care.
 
-//mod gcd;
+pub(crate) mod gcd;
 pub(crate) mod jacobi;
 mod lucas;
 mod miller_rabin;
@@ -12,6 +12,7 @@ pub(crate) mod primes;
 pub(crate) mod pseudoprimes;
 mod sieve;
 
+pub use jacobi::JacobiSymbol;
 pub use lucas::{lucas_test, AStarBase, BruteForceBase, LucasBase, LucasCheck, SelfridgeBase};
 pub use miller_rabin::MillerRabin;
 pub use sieve::{random_odd_uint, Sieve};

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -2,7 +2,7 @@
 //! Handle with care.
 
 //mod gcd;
-//mod jacobi;
+mod jacobi;
 mod lucas;
 mod miller_rabin;
 mod precomputed;

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -1,20 +1,20 @@
 //! Components to build your own primality test.
 //! Handle with care.
 
-mod gcd;
-mod jacobi;
+//mod gcd;
+//mod jacobi;
 mod lucas;
-mod miller_rabin;
-mod precomputed;
+//mod miller_rabin;
+//mod precomputed;
 #[cfg(test)]
 pub(crate) mod primes;
 #[cfg(test)]
 pub(crate) mod pseudoprimes;
-mod sieve;
+//mod sieve;
 
 pub use lucas::{lucas_test, AStarBase, BruteForceBase, LucasBase, LucasCheck, SelfridgeBase};
-pub use miller_rabin::MillerRabin;
-pub use sieve::{random_odd_uint, Sieve};
+//pub use miller_rabin::MillerRabin;
+//pub use sieve::{random_odd_uint, Sieve};
 
 /// Possible results of various primality tests.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -5,12 +5,12 @@
 //mod jacobi;
 mod lucas;
 //mod miller_rabin;
-//mod precomputed;
+mod precomputed;
 #[cfg(test)]
 pub(crate) mod primes;
 #[cfg(test)]
 pub(crate) mod pseudoprimes;
-//mod sieve;
+mod sieve;
 
 pub use lucas::{lucas_test, AStarBase, BruteForceBase, LucasBase, LucasCheck, SelfridgeBase};
 //pub use miller_rabin::MillerRabin;

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -2,7 +2,7 @@
 //! Handle with care.
 
 //mod gcd;
-mod jacobi;
+pub(crate) mod jacobi;
 mod lucas;
 mod miller_rabin;
 mod precomputed;

--- a/src/hazmat/gcd.rs
+++ b/src/hazmat/gcd.rs
@@ -1,4 +1,4 @@
-use crypto_bigint::{Limb, NonZero, Uint};
+use crypto_bigint::{Limb, NonZero};
 
 use crate::UintLike;
 

--- a/src/hazmat/gcd.rs
+++ b/src/hazmat/gcd.rs
@@ -49,7 +49,7 @@ pub(crate) fn gcd<T: UintLike>(n: &T, m: u32) -> u32 {
 
 #[cfg(test)]
 mod tests {
-    use crypto_bigint::{Encoding, U128};
+    use crypto_bigint::U128;
     use num_bigint::BigUint;
     use num_integer::Integer;
     use proptest::prelude::*;

--- a/src/hazmat/gcd.rs
+++ b/src/hazmat/gcd.rs
@@ -1,9 +1,11 @@
 use crypto_bigint::{Limb, NonZero, Uint};
 
+use crate::UintLike;
+
 /// Calculates the greatest common divisor of `n` and `m`.
 /// By definition, `gcd(0, m) == m`.
 /// `n` must be non-zero.
-pub(crate) fn gcd<const L: usize>(n: &Uint<L>, m: u32) -> u32 {
+pub(crate) fn gcd<T: UintLike>(n: &T, m: u32) -> u32 {
     // This is an internal function, and it will never be called with `m = 0`.
     // Allowing `m = 0` would require us to have the return type of `Uint<L>`
     // (since `gcd(n, 0) = n`).
@@ -11,12 +13,12 @@ pub(crate) fn gcd<const L: usize>(n: &Uint<L>, m: u32) -> u32 {
 
     // This we can check since it doesn't affect the return type,
     // even though `n` will not be 0 either in the application.
-    if n == &Uint::<L>::ZERO {
+    if n.is_zero().into() {
         return m;
     }
 
     // Normalize input: the resulting (a, b) are both small, a >= b, and b != 0.
-    let (mut a, mut b): (u32, u32) = if n.bits() > (u32::BITS as usize) {
+    let (mut a, mut b): (u32, u32) = if n.bits() > u32::BITS {
         // `m` is non-zero, so we can unwrap.
         let (_quo, n) = n.div_rem_limb(NonZero::new(Limb::from(m)).unwrap());
         // `n` is a remainder of a division by `u32`, so it can be safely cast to `u32`.

--- a/src/hazmat/jacobi.rs
+++ b/src/hazmat/jacobi.rs
@@ -2,12 +2,12 @@
 
 use core::fmt::Display;
 
-use crypto_bigint::{Limb, NonZero, Uint, Word, BoxedUint};
+use crypto_bigint::{BoxedUint, Limb, NonZero, Uint, Word};
 
 use crate::UintLike;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub(crate) enum JacobiSymbol {
+pub enum JacobiSymbol {
     Zero,
     One,
     MinusOne,
@@ -25,7 +25,7 @@ impl core::ops::Neg for JacobiSymbol {
 }
 
 // A helper trait to generalize some functions over Word and Uint.
-trait SmallMod {
+pub(crate) trait SmallMod {
     fn mod8(&self) -> Word;
     fn mod4(&self) -> Word;
 }
@@ -108,7 +108,7 @@ pub(crate) fn jacobi_symbol<T: UintLike + Display + SmallMod>(a: i32, p_long: &T
     };
 
     // A degenerate case.
-    if a_pos == 1 || p_long == T.oneONE {
+    if a_pos == 1 || p_long == &T::one() {
         return result;
     }
 
@@ -124,7 +124,9 @@ pub(crate) fn jacobi_symbol<T: UintLike + Display + SmallMod>(a: i32, p_long: &T
         if a == 1 {
             return result;
         }
-        let (result, a_long, p) = swap(result, a, *p_long);
+        // TODO: used to be *p_long because Uint implements Copy
+        // However, BoxedUint does not implement Copy. Is clone the best idea?
+        let (result, a_long, p) = swap(result, a, p_long.clone());
         // Can unwrap here, since `p` is swapped with `a`,
         // and `a` would be odd after `reduce_numerator()`.
         let (_, a) = a_long.div_rem_limb(NonZero::new(Limb::from(p)).unwrap());

--- a/src/hazmat/jacobi.rs
+++ b/src/hazmat/jacobi.rs
@@ -125,8 +125,9 @@ pub(crate) fn jacobi_symbol<T: UintLike + Display + SmallMod>(a: i32, p_long: &T
         if a == 1 {
             return result;
         }
-        // TODO: used to be *p_long because Uint implements Copy
-        // However, BoxedUint does not implement Copy. Is clone the best idea?
+        // NOTE: prior to the UintLike generics it was *p_long, which works because Uint implements
+        // Copy. However, BoxedUint does not implement Copy (which it should not anyways since it
+        // is heap-allocated), so explicit cloning is the next best thing
         let (result, a_long, p) = swap(result, a, p_long.clone());
         // Can unwrap here, since `p` is swapped with `a`,
         // and `a` would be odd after `reduce_numerator()`.

--- a/src/hazmat/jacobi.rs
+++ b/src/hazmat/jacobi.rs
@@ -6,6 +6,7 @@ use crypto_bigint::{BoxedUint, Limb, NonZero, Uint, Word};
 
 use crate::UintLike;
 
+#[allow(missing_docs)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum JacobiSymbol {
     Zero,

--- a/src/hazmat/jacobi.rs
+++ b/src/hazmat/jacobi.rs
@@ -109,7 +109,7 @@ pub(crate) fn jacobi_symbol<T: UintLike + Display + SmallMod>(a: i32, p_long: &T
     };
 
     // A degenerate case.
-    if a_pos == 1 || p_long == &T::one() {
+    if a_pos == 1 || p_long == &T::one_with_precision(p_long.bits_precision()) {
         return result;
     }
 

--- a/src/hazmat/jacobi.rs
+++ b/src/hazmat/jacobi.rs
@@ -169,7 +169,7 @@ mod tests {
 
     use alloc::format;
 
-    use crypto_bigint::{Encoding, U128};
+    use crypto_bigint::U128;
     use num_bigint::{BigInt, Sign};
     use num_modular::ModularSymbols;
     use proptest::prelude::*;

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -370,12 +370,12 @@ pub fn lucas_test<T: UintLike>(
     for i in (0..d.bits_vartime()).rev() {
         // k' = k * 2
 
-        let q_2k = qk.square();
-        let u_2k = uk * &vk;
+        let q_2k = qk.square().refresh();
+        let u_2k = (uk * &vk).refresh();
 
         dbg!(i, &qk, &vk);
 
-        let v_2k = vk.square() - &(qk.clone() + &qk);
+        let v_2k = vk.square().refresh() - &(qk.clone() + &qk);
 
         uk = u_2k;
         vk = v_2k;
@@ -387,16 +387,16 @@ pub fn lucas_test<T: UintLike>(
             let (p_uk, p_vk) = if p_is_one {
                 (uk.clone(), vk.clone())
             } else {
-                (p.clone() * &uk, p.clone() * &vk)
+                ((p.clone() * &uk).refresh(), (p.clone() * &vk).refresh())
             };
 
-            let u_k1 = (p_uk + &vk).div_by_2();
-            let v_k1 = (d_m.clone() * &uk + &p_vk).div_by_2();
+            let u_k1 = (p_uk + &vk).div_by_2().refresh();
+            let v_k1 = ((d_m.clone() * &uk).refresh() + &p_vk).div_by_2().refresh();
             let q_k1 = qk * &q;
 
             uk = u_k1;
             vk = v_k1;
-            qk = q_k1;
+            qk = q_k1.refresh();
         }
     }
 
@@ -450,21 +450,21 @@ pub fn lucas_test<T: UintLike>(
 
         // k' = 2k
         // V_{k'} = V_k^2 - 2 Q^k
-        vk = vk.square() - &qk - &qk;
+        vk = vk.square().refresh() - &qk - &qk;
 
         if check != LucasCheck::LucasV && vk == zero {
             return Primality::ProbablyPrime;
         }
 
         if !q_is_one {
-            qk = qk.square();
+            qk = qk.square().refresh();
         }
     }
 
     if check == LucasCheck::LucasV {
         // At this point vk = V_{d * 2^(s-1)}.
         // Double the index again:
-        vk = vk.square() - &qk - &qk; // now vk = V_{d * 2^s} = V_{n+1}
+        vk = vk.square().refresh() - &qk - &qk; // now vk = V_{d * 2^s} = V_{n+1}
 
         // Lucas-V check[^Baillie2021]: if V_{n+1} == 2 Q, report `n` as prime.
         if vk == q.clone() + &q {

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -1,6 +1,7 @@
 //! Lucas primality test.
 
-use crate::{JacobiSymbol, UintLike, UintModLike};
+use crate::{UintLike, UintModLike};
+use crate::hazmat::jacobi::JacobiSymbol;
 
 use super::Primality;
 

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -549,8 +549,9 @@ mod tests {
     #[test]
     fn decomposition() {
         assert_eq!(decompose(&U128::MAX), (128, U128::ONE));
-        assert_eq!(decompose(&U128::ONE), (1, U128::ONE));
+        assert_eq!(decompose(&U128::ONE), (1, U128::ONE)); // OK
         assert_eq!(decompose(&U128::from(7766015u32)), (15, U128::from(237u32)));
+        // OK
     }
 
     fn is_slpsp(num: u32) -> bool {

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -172,9 +172,7 @@ fn decompose<T: UintLike>(n: &T) -> (u32, T) {
 
     let s = n.trailing_ones();
     // This won't overflow since the original `n` was odd, so we right-shifted at least once.
-    // TODO: shr(s-1).shr(1) is a hack around the fact that a full right shift will panic
-    // see https://github.com/RustCrypto/crypto-bigint/commit/55312b6aa71#r134960147
-    let d = Option::from((n.clone().shr(s - 1).shr(1)).checked_add(&T::one()))
+    let d = Option::from((n.clone().shr_vartime(s).0).checked_add(&T::one()))
         .expect("Integer overflow");
 
     (s, d)
@@ -551,7 +549,6 @@ mod tests {
 
     #[test]
     fn decomposition() {
-        // TODO: the first one overflows
         assert_eq!(decompose(&U128::MAX), (128, U128::ONE));
         assert_eq!(decompose(&U128::ONE), (1, U128::ONE));
         assert_eq!(decompose(&U128::from(7766015u32)), (15, U128::from(237u32)));

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -478,7 +478,7 @@ mod tests {
 
     use alloc::format;
 
-    use crypto_bigint::{Uint, U128, U64};
+    use crypto_bigint::{BoxedUint, Uint, U128, U64};
 
     #[cfg(feature = "tests-exhaustive")]
     use num_prime::nt_funcs::is_prime64;
@@ -512,6 +512,12 @@ mod tests {
         assert_eq!(SelfridgeBase.generate(&num), Err(Primality::Composite));
         assert_eq!(AStarBase.generate(&num), Err(Primality::Composite));
         assert_eq!(BruteForceBase.generate(&num), Err(Primality::Composite));
+
+        // The same test, but with BoxedUint
+        let num = BoxedUint::from(131u32).widen(64).square();
+        assert_eq!(SelfridgeBase.generate(&num), Err(Primality::Composite));
+        assert_eq!(AStarBase.generate(&num), Err(Primality::Composite));
+        assert_eq!(BruteForceBase.generate(&num), Err(Primality::Composite));
     }
 
     #[test]
@@ -520,7 +526,11 @@ mod tests {
         assert_eq!(
             BruteForceBase.generate(&U64::from(5u32)),
             Err(Primality::Prime)
-        )
+        );
+        assert_eq!(
+            BruteForceBase.generate(&BoxedUint::from(5u32).widen(64)),
+            Err(Primality::Prime)
+        );
     }
 
     #[test]
@@ -528,6 +538,10 @@ mod tests {
         // If the number is even, no need to run the test.
         assert_eq!(
             lucas_test(&U64::from(6u32), SelfridgeBase, LucasCheck::Strong),
+            Primality::Composite
+        );
+        assert_eq!(
+            lucas_test(&BoxedUint::from(6u32), SelfridgeBase, LucasCheck::Strong),
             Primality::Composite
         );
     }
@@ -552,6 +566,14 @@ mod tests {
             lucas_test(&U64::from(15u32), TestBase, LucasCheck::Strong),
             Primality::Composite
         );
+        assert_eq!(
+            lucas_test(
+                &BoxedUint::from(15u32).widen(64),
+                TestBase,
+                LucasCheck::Strong
+            ),
+            Primality::Composite
+        );
     }
 
     #[test]
@@ -559,6 +581,19 @@ mod tests {
         assert_eq!(decompose(&U128::MAX), (128, U128::ONE));
         assert_eq!(decompose(&U128::ONE), (1, U128::ONE));
         assert_eq!(decompose(&U128::from(7766015u32)), (15, U128::from(237u32)));
+
+        assert_eq!(
+            decompose(&BoxedUint::from(u128::MAX)),
+            (128, BoxedUint::one_with_precision(128))
+        );
+        assert_eq!(
+            decompose(&BoxedUint::one_with_precision(128)),
+            (1, BoxedUint::one_with_precision(128))
+        );
+        assert_eq!(
+            decompose(&BoxedUint::from(7766015u32)),
+            (15, BoxedUint::from(237u32))
+        );
     }
 
     fn is_slpsp(num: u32) -> bool {

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -163,7 +163,7 @@ impl LucasBase for BruteForceBase {
 }
 
 /// For the given odd `n`, finds `s` and odd `d` such that `n + 1 == 2^s * d`.
-fn decompose<T: UintLike>(n: &T) -> (usize, T) {
+fn decompose<T: UintLike>(n: &T) -> (u32, T) {
     debug_assert!(bool::from(n.is_odd()));
 
     // Need to be careful here since `n + 1` can overflow.

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -370,10 +370,10 @@ pub fn lucas_test<T: UintLike>(
     for i in (0..d.bits_vartime()).rev() {
         // k' = k * 2
 
-        let q_2k = qk.square().refresh();
-        let u_2k = (uk * &vk).refresh();
+        let q_2k = qk.square();
+        let u_2k = uk * &vk;
 
-        let v_2k = vk.square().refresh() - &(qk.clone() + &qk);
+        let v_2k = vk.square() - &(qk.clone() + &qk);
 
         uk = u_2k;
         vk = v_2k;
@@ -385,16 +385,16 @@ pub fn lucas_test<T: UintLike>(
             let (p_uk, p_vk) = if p_is_one {
                 (uk.clone(), vk.clone())
             } else {
-                ((p.clone() * &uk).refresh(), (p.clone() * &vk).refresh())
+                ((p.clone() * &uk), (p.clone() * &vk))
             };
 
-            let u_k1 = (p_uk + &vk).div_by_2().refresh();
-            let v_k1 = ((d_m.clone() * &uk).refresh() + &p_vk).div_by_2().refresh();
+            let u_k1 = (p_uk + &vk).div_by_2();
+            let v_k1 = ((d_m.clone() * &uk) + &p_vk).div_by_2();
             let q_k1 = qk * &q;
 
             uk = u_k1;
             vk = v_k1;
-            qk = q_k1.refresh();
+            qk = q_k1;
         }
     }
 
@@ -448,21 +448,21 @@ pub fn lucas_test<T: UintLike>(
 
         // k' = 2k
         // V_{k'} = V_k^2 - 2 Q^k
-        vk = vk.square().refresh() - &qk - &qk;
+        vk = vk.square() - &qk - &qk;
 
         if check != LucasCheck::LucasV && vk == zero {
             return Primality::ProbablyPrime;
         }
 
         if !q_is_one {
-            qk = qk.square().refresh();
+            qk = qk.square();
         }
     }
 
     if check == LucasCheck::LucasV {
         // At this point vk = V_{d * 2^(s-1)}.
         // Double the index again:
-        vk = vk.square().refresh() - &qk - &qk; // now vk = V_{d * 2^s} = V_{n+1}
+        vk = vk.square() - &qk - &qk; // now vk = V_{d * 2^s} = V_{n+1}
 
         // Lucas-V check[^Baillie2021]: if V_{n+1} == 2 Q, report `n` as prime.
         if vk == q.clone() + &q {

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -172,7 +172,10 @@ fn decompose<T: UintLike>(n: &T) -> (u32, T) {
 
     let s = n.trailing_ones();
     // This won't overflow since the original `n` was odd, so we right-shifted at least once.
-    let d = Option::from((n.clone() >> s).checked_add(&T::one())).expect("Integer overflow");
+    // TODO: shr(s-1).shr(1) is a hack around the fact that a full right shift will panic
+    // see https://github.com/RustCrypto/crypto-bigint/commit/55312b6aa71#r134960147
+    let d = Option::from((n.clone().shr(s - 1).shr(1)).checked_add(&T::one()))
+        .expect("Integer overflow");
 
     (s, d)
 }
@@ -548,10 +551,10 @@ mod tests {
 
     #[test]
     fn decomposition() {
+        // TODO: the first one overflows
         assert_eq!(decompose(&U128::MAX), (128, U128::ONE));
-        assert_eq!(decompose(&U128::ONE), (1, U128::ONE)); // OK
+        assert_eq!(decompose(&U128::ONE), (1, U128::ONE));
         assert_eq!(decompose(&U128::from(7766015u32)), (15, U128::from(237u32)));
-        // OK
     }
 
     fn is_slpsp(num: u32) -> bool {

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -53,7 +53,7 @@ impl LucasBase for SelfridgeBase {
 
             if attempts >= ATTEMPTS_BEFORE_SQRT {
                 let sqrt_n = n.sqrt_vartime();
-                if &sqrt_n.wrapping_mul(&sqrt_n) == n {
+                if &<T as UintLike>::wrapping_mul(&sqrt_n, &sqrt_n) == n {
                     return Err(Primality::Composite);
                 }
             }
@@ -130,7 +130,7 @@ impl LucasBase for BruteForceBase {
 
             if attempts >= ATTEMPTS_BEFORE_SQRT {
                 let sqrt_n = n.sqrt_vartime();
-                if &sqrt_n.wrapping_mul(&sqrt_n) == n {
+                if &<T as UintLike>::wrapping_mul(&sqrt_n, &sqrt_n) == n {
                     return Err(Primality::Composite);
                 }
             }

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -1,7 +1,7 @@
 //! Lucas primality test.
 
-use crate::{UintLike, UintModLike};
 use crate::hazmat::jacobi::JacobiSymbol;
+use crate::{UintLike, UintModLike};
 
 use super::Primality;
 

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -373,8 +373,6 @@ pub fn lucas_test<T: UintLike>(
         let q_2k = qk.square().refresh();
         let u_2k = (uk * &vk).refresh();
 
-        dbg!(i, &qk, &vk);
-
         let v_2k = vk.square().refresh() - &(qk.clone() + &qk);
 
         uk = u_2k;

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -171,7 +171,7 @@ fn decompose<T: UintLike>(n: &T) -> (usize, T) {
 
     let s = n.trailing_ones();
     // This won't overflow since the original `n` was odd, so we right-shifted at least once.
-    let d = Option::from(n.shr(s).checked_add(&T::one())).expect("Integer overflow");
+    let d = Option::from((n.clone() >> s).checked_add(&T::one())).expect("Integer overflow");
 
     (s, d)
 }

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -172,8 +172,10 @@ fn decompose<T: UintLike>(n: &T) -> (u32, T) {
 
     let s = n.trailing_ones();
     // This won't overflow since the original `n` was odd, so we right-shifted at least once.
-    let d = Option::from((n.clone().shr_vartime(s).0).checked_add(&T::one()))
-        .expect("Integer overflow");
+    let d = Option::from(
+        (n.clone().shr_vartime(s).0).checked_add(&T::one_with_precision(n.bits_precision())),
+    )
+    .expect("Integer overflow");
 
     (s, d)
 }

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -41,7 +41,10 @@ impl<T: UintLike> MillerRabin<T> {
         let minus_one = -one.clone();
 
         // Find `s` and odd `d` such that `candidate - 1 == 2^s * d`.
-        let candidate_minus_one = <T as UintLike>::wrapping_sub(candidate, &T::one());
+        let candidate_minus_one = <T as UintLike>::wrapping_sub(
+            candidate,
+            &T::one_with_precision(candidate.bits_precision()),
+        );
         let s = candidate_minus_one.trailing_zeros();
         let d = candidate_minus_one.shr_vartime(s).0;
 

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -17,11 +17,11 @@ use crate::{UintLike, UintModLike};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MillerRabin<T: UintLike> {
     candidate: T,
-    bit_length: usize,
+    bit_length: u32,
     montgomery_params: <T::Modular as UintModLike>::Params,
     one: T::Modular,
     minus_one: T::Modular,
-    s: usize,
+    s: u32,
     d: T,
 }
 

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -43,8 +43,7 @@ impl<T: UintLike> MillerRabin<T> {
         // Find `s` and odd `d` such that `candidate - 1 == 2^s * d`.
         let candidate_minus_one = candidate.wrapping_sub(&T::one());
         let s = candidate_minus_one.trailing_zeros();
-        // TODO: https://github.com/RustCrypto/crypto-bigint/commit/55312b6aa71#r134960147
-        let d = candidate_minus_one.shr(s - 1).shr(1);
+        let d = candidate_minus_one.shr_vartime(s).0;
 
         Self {
             candidate: candidate.clone(),

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -41,7 +41,7 @@ impl<T: UintLike> MillerRabin<T> {
         let minus_one = -one.clone();
 
         // Find `s` and odd `d` such that `candidate - 1 == 2^s * d`.
-        let candidate_minus_one = candidate.wrapping_sub(&T::one());
+        let candidate_minus_one = <T as UintLike>::wrapping_sub(candidate, &T::one());
         let s = candidate_minus_one.trailing_zeros();
         let d = candidate_minus_one.shr_vartime(s).0;
 
@@ -101,7 +101,7 @@ impl<T: UintLike> MillerRabin<T> {
             panic!("No suitable random base possible when `candidate == 3`; use the base 2 test.")
         }
 
-        let range = self.candidate.wrapping_sub(&T::from(4u32));
+        let range = <T as UintLike>::wrapping_sub(&self.candidate, &T::from(4u32));
         let range_nonzero = NonZero::new(range).unwrap();
         // This should not overflow as long as `random_mod()` behaves according to the contract
         // (that is, returns a number within the given range).

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -89,7 +89,7 @@ impl<T: UintLike> MillerRabin<T> {
 
     /// Perform a Miller-Rabin check with base 2.
     pub fn test_base_two(&self) -> Primality {
-        self.test(&T::from(2u32))
+        self.test(&T::from(2u32).widen(self.candidate.bits_precision()))
     }
 
     /// Perform a Miller-Rabin check with a random base (in the range `[3, candidate-2]`)
@@ -104,12 +104,18 @@ impl<T: UintLike> MillerRabin<T> {
             panic!("No suitable random base possible when `candidate == 3`; use the base 2 test.")
         }
 
-        let range = <T as UintLike>::wrapping_sub(&self.candidate, &T::from(4u32));
+        let range = <T as UintLike>::wrapping_sub(
+            &self.candidate,
+            &T::from(4u32).widen(self.candidate.bits_precision()),
+        );
         let range_nonzero = NonZero::new(range).unwrap();
         // This should not overflow as long as `random_mod()` behaves according to the contract
         // (that is, returns a number within the given range).
-        let random = Option::from(T::random_mod(rng, &range_nonzero).checked_add(&T::from(3u32)))
-            .expect("Integer overflow");
+        let random = Option::from(
+            T::random_mod(rng, &range_nonzero)
+                .checked_add(&T::from(3u32).widen(self.candidate.bits_precision())),
+        )
+        .expect("Integer overflow");
         self.test(&random)
     }
 }

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -195,7 +195,7 @@ mod tests {
     #[test]
     fn trivial() {
         let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
-        let start: U1024 = random_odd_uint(&mut rng, 1024);
+        let start: U1024 = random_odd_uint(&mut rng, 1024, U1024::BITS);
         for num in Sieve::new(&start, 1024, false).take(10) {
             let mr = MillerRabin::new(&num);
 

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -43,7 +43,8 @@ impl<T: UintLike> MillerRabin<T> {
         // Find `s` and odd `d` such that `candidate - 1 == 2^s * d`.
         let candidate_minus_one = candidate.wrapping_sub(&T::one());
         let s = candidate_minus_one.trailing_zeros();
-        let d = candidate_minus_one.shr(s);
+        // TODO: https://github.com/RustCrypto/crypto-bigint/commit/55312b6aa71#r134960147
+        let d = candidate_minus_one.shr(s - 1).shr(1);
 
         Self {
             candidate: candidate.clone(),
@@ -196,7 +197,7 @@ mod tests {
     fn trivial() {
         let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
         let start: U1024 = random_odd_uint(&mut rng, 1024, U1024::BITS);
-        for num in Sieve::new(&start, 1024, false).take(10) {
+        for num in Sieve::new(&start, 1024, false, U1024::BITS).take(10) {
             let mr = MillerRabin::new(&num);
 
             // Trivial tests, must always be true.

--- a/src/hazmat/precomputed.rs
+++ b/src/hazmat/precomputed.rs
@@ -151,7 +151,7 @@ const fn create_reciprocals() -> [Reciprocal; SMALL_PRIMES_SIZE] {
     let mut arr = [Reciprocal::default(); SMALL_PRIMES_SIZE];
     let mut i = 0;
     while i < SMALL_PRIMES_SIZE {
-        let limb = NonZero::new(Limb(SMALL_PRIMES[i] as Word)).expect("Small prime is zero");
+        let limb = NonZero::<Limb>::const_new(Limb(SMALL_PRIMES[i] as Word)).0;
         arr[i] = Reciprocal::new(limb);
         i += 1;
     }

--- a/src/hazmat/precomputed.rs
+++ b/src/hazmat/precomputed.rs
@@ -151,7 +151,8 @@ const fn create_reciprocals() -> [Reciprocal; SMALL_PRIMES_SIZE] {
     let mut arr = [Reciprocal::default(); SMALL_PRIMES_SIZE];
     let mut i = 0;
     while i < SMALL_PRIMES_SIZE {
-        let limb = NonZero::<Limb>::const_new(Limb(SMALL_PRIMES[i] as Word)).0;
+        let limb =
+            NonZero::<Limb>::const_new(Limb(SMALL_PRIMES[i] as Word)).expect("Prime is zero");
         arr[i] = Reciprocal::new(limb);
         i += 1;
     }

--- a/src/hazmat/precomputed.rs
+++ b/src/hazmat/precomputed.rs
@@ -1,4 +1,4 @@
-use crypto_bigint::{Limb, Reciprocal, Word};
+use crypto_bigint::{Limb, NonZero, Reciprocal, Word};
 
 /// The type that fits any small prime from the table.
 pub(crate) type SmallPrime = u16;
@@ -151,7 +151,8 @@ const fn create_reciprocals() -> [Reciprocal; SMALL_PRIMES_SIZE] {
     let mut arr = [Reciprocal::default(); SMALL_PRIMES_SIZE];
     let mut i = 0;
     while i < SMALL_PRIMES_SIZE {
-        arr[i] = Reciprocal::ct_new(Limb(SMALL_PRIMES[i] as Word)).0;
+        let limb = NonZero::new(Limb(SMALL_PRIMES[i] as Word)).expect("Small prime is zero");
+        arr[i] = Reciprocal::new(limb);
         i += 1;
     }
     arr

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -41,7 +41,7 @@ pub fn random_odd_uint<T: UintLike>(
     let random = random | T::one();
 
     // Make sure it's the correct bit size
-    let random = random | T::one().shr(bit_length - 1);
+    let random = random | T::one().shl_vartime(bit_length - 1).0;
 
     random
 }

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -14,7 +14,7 @@ use crate::{
 /// (that is, with both `0` and `bit_length-1` bits set).
 ///
 /// Panics if `bit_length` is 0 or is greater than the bit size of the target `Uint`.
-pub fn random_odd_uint<T: UintLike>(rng: &mut impl CryptoRngCore, bit_length: usize) -> T {
+pub fn random_odd_uint<T: UintLike>(rng: &mut impl CryptoRngCore, bit_length: u32) -> T {
     if bit_length == 0 {
         panic!("Bit length must be non-zero");
     }
@@ -60,7 +60,7 @@ pub struct Sieve<T: UintLike> {
     incr_limit: Residue,
     safe_primes: bool,
     residues: Vec<SmallPrime>,
-    max_bit_length: usize,
+    max_bit_length: u32,
     produces_nothing: bool,
     starts_from_exception: bool,
     last_round: bool,
@@ -79,7 +79,7 @@ impl<T: UintLike> Sieve<T> {
     /// Panics if `max_bit_length` is zero or greater than the size of the target `Uint`.
     ///
     /// If `safe_primes` is `true`, both the returned `n` and `n/2` are sieved.
-    pub fn new(start: &T, max_bit_length: usize, safe_primes: bool) -> Self {
+    pub fn new(start: &T, max_bit_length: u32, safe_primes: bool) -> Self {
         if max_bit_length == 0 {
             panic!("The requested bit length cannot be zero");
         }
@@ -297,7 +297,7 @@ mod tests {
         }
     }
 
-    fn check_sieve(start: u32, bit_length: usize, safe_prime: bool, reference: &[u32]) {
+    fn check_sieve(start: u32, bit_length: u32, safe_prime: bool, reference: &[u32]) {
         let test = Sieve::new(&U64::from(start), bit_length, safe_prime).collect::<Vec<_>>();
         assert_eq!(test.len(), reference.len());
         for (x, y) in test.iter().zip(reference.iter()) {

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -174,11 +174,9 @@ impl<T: UintLike> Sieve<T> {
         }
 
         // Find the increment limit.
-        let max_value = T::one()
-            .shl_vartime(self.max_bit_length)
-            .0
-            .wrapping_sub(&T::one());
-        let incr_limit = max_value.wrapping_sub(&self.base);
+        let max_value =
+            <T as UintLike>::wrapping_sub(&T::one().shl_vartime(self.max_bit_length).0, &T::one());
+        let incr_limit = <T as UintLike>::wrapping_sub(&max_value, &self.base);
         self.incr_limit = if incr_limit > INCR_LIMIT.into() {
             INCR_LIMIT
         } else {

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -35,7 +35,7 @@ pub fn random_odd_uint<T: UintLike>(
     }
 
     // TODO: not particularly efficient, can be improved by zeroing high bits instead of shifting
-    let random = T::random_bits(rng, bit_length);
+    let random = T::random_bits(rng, bit_length, bits_precision);
 
     // Make it odd
     let random = random | T::one();

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -96,7 +96,7 @@ impl<T: UintLike> Sieve<T> {
         // If we are targeting safe primes, iterate over the corresponding
         // possible Germain primes (`n/2`), reducing the task to that with `safe_primes = false`.
         let (max_bit_length, base) = if safe_primes {
-            (max_bit_length - 1, start.shr_vartime(1))
+            (max_bit_length - 1, start.shr_vartime(1).0)
         } else {
             (max_bit_length, start.clone())
         };
@@ -172,6 +172,7 @@ impl<T: UintLike> Sieve<T> {
         // Find the increment limit.
         let max_value = T::one()
             .shl_vartime(self.max_bit_length)
+            .0
             .wrapping_sub(&T::one());
         let incr_limit = max_value.wrapping_sub(&self.base);
         self.incr_limit = if incr_limit > INCR_LIMIT.into() {
@@ -225,7 +226,7 @@ impl<T: UintLike> Sieve<T> {
             let mut num: T =
                 Option::from(self.base.checked_add(&self.incr.into())).expect("Integer overflow");
             if self.safe_primes {
-                num = num.shl_vartime(1) | T::one();
+                num = num.shl_vartime(1).0 | T::one();
             }
             Some(num)
         };

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -114,7 +114,7 @@ impl<T: UintLike> Sieve<T> {
             base = T::from(3u32);
         } else {
             // Adjust the base so that we hit odd numbers when incrementing it by 2.
-            base |= T::one();
+            base = base | T::one();
         }
 
         // Only calculate residues by primes up to and not including `base`,

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -16,7 +16,8 @@ use crate::{
 /// Where T is stack allocated (Uint), `bits_precision` must be exactly `T::BITS`. Where T is
 /// heap-allocated (BoxedUint), `bits_precision` will be passed to the appropriate type.
 ///
-/// Panics if `bit_length` is 0 or is greater than the bit size of the target `Uint`.
+/// If `bit_length` is greater than `bits_precision`, or if `bit_length` is 0, this function will
+/// panic
 pub fn random_odd_uint<T: UintLike>(
     rng: &mut impl CryptoRngCore,
     bit_length: u32,
@@ -26,8 +27,6 @@ pub fn random_odd_uint<T: UintLike>(
         panic!("Bit length must be non-zero");
     }
 
-    // TODO: what do we do here if `bit_length` is greater than Uint<L>::BITS?
-    // assume that the user knows what he's doing since it is a hazmat function?
     if bit_length > bits_precision {
         panic!(
             "The requested bit length ({}) is larger than the chosen Uint size",
@@ -83,7 +82,7 @@ impl<T: UintLike> Sieve<T> {
     /// Note that `start` is adjusted to `2`, or the next `1 mod 2` number (`safe_primes = false`);
     /// and `5`, or `3 mod 4` number (`safe_primes = true`).
     ///
-    /// Panics if `max_bit_length` is zero or greater than the size of the target `Uint`.
+    /// Panics if `max_bit_length` is zero or greater than `bits_precision`
     ///
     /// If `safe_primes` is `true`, both the returned `n` and `n/2` are sieved.
     pub fn new(start: &T, max_bit_length: u32, safe_primes: bool, bits_precision: u32) -> Self {
@@ -91,8 +90,6 @@ impl<T: UintLike> Sieve<T> {
             panic!("The requested bit length cannot be zero");
         }
 
-        // TODO: what do we do here if `bit_length` is greater than Uint<L>::BITS?
-        // assume that the user knows what he's doing since it is a hazmat function?
         if max_bit_length > bits_precision {
             panic!(
                 "The requested bit length ({}) is larger than the chosen Uint size",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,16 +17,16 @@ extern crate alloc;
 
 pub mod hazmat;
 mod presets;
-//mod traits;
+mod traits;
 mod uint_traits;
 
-//pub use presets::{
-//    generate_prime_with_rng, generate_safe_prime_with_rng, is_prime_with_rng,
-//    is_safe_prime_with_rng,
-//};
-//pub use traits::RandomPrimeWithRng;
+pub use presets::{
+    generate_prime_with_rng, generate_safe_prime_with_rng, is_prime_with_rng,
+    is_safe_prime_with_rng,
+};
+pub use traits::RandomPrimeWithRng;
 
-//#[cfg(feature = "default-rng")]
-//pub use presets::{generate_prime, generate_safe_prime, is_prime, is_safe_prime};
+#[cfg(feature = "default-rng")]
+pub use presets::{generate_prime, generate_safe_prime, is_prime, is_safe_prime};
 
 pub use uint_traits::{JacobiSymbol, UintLike, UintModLike};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 extern crate alloc;
 
 pub mod hazmat;
-//mod presets;
+mod presets;
 //mod traits;
 mod uint_traits;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,14 +16,17 @@
 extern crate alloc;
 
 pub mod hazmat;
-mod presets;
-mod traits;
+//mod presets;
+//mod traits;
+mod uint_traits;
 
-pub use presets::{
-    generate_prime_with_rng, generate_safe_prime_with_rng, is_prime_with_rng,
-    is_safe_prime_with_rng,
-};
-pub use traits::RandomPrimeWithRng;
+//pub use presets::{
+//    generate_prime_with_rng, generate_safe_prime_with_rng, is_prime_with_rng,
+//    is_safe_prime_with_rng,
+//};
+//pub use traits::RandomPrimeWithRng;
 
-#[cfg(feature = "default-rng")]
-pub use presets::{generate_prime, generate_safe_prime, is_prime, is_safe_prime};
+//#[cfg(feature = "default-rng")]
+//pub use presets::{generate_prime, generate_safe_prime, is_prime, is_safe_prime};
+
+pub use uint_traits::{JacobiSymbol, UintLike, UintModLike};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,4 +29,4 @@ pub use traits::RandomPrimeWithRng;
 #[cfg(feature = "default-rng")]
 pub use presets::{generate_prime, generate_safe_prime, is_prime, is_safe_prime};
 
-pub use uint_traits::{JacobiSymbol, UintLike, UintModLike};
+pub use uint_traits::{UintLike, UintModLike};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+// #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![deny(unsafe_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// #![no_std]
+// #![no_std]  // TODO: uncomment this after finishing debugging
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![deny(unsafe_code)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,9 @@
+use crypto_bigint::{Integer, Random, U128};
+use rand_core::OsRng;
+
+fn main() {
+    let max = U128::MAX;
+    let s = max.trailing_ones();
+    println!("{}, {}", max, s);
+    println!("{}", max.clone().shr(s).0);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,0 @@
-use crypto_bigint::{Integer, Random, U128};
-use rand_core::OsRng;
-
-fn main() {
-    let max = U128::MAX;
-    let s = max.trailing_ones();
-    println!("{}, {}", max, s);
-    println!("{}", max.clone().shr(s).0);
-}

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -137,7 +137,7 @@ pub fn is_safe_prime_with_rng<T: UintLike>(rng: &mut impl CryptoRngCore, num: &T
     if num == &T::from(5u32) {
         return true;
     }
-    if T::from(3u32) & num != T::from(3u32) {
+    if T::from(3u32) & num.clone() != T::from(3u32) {
         return false;
     }
 

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -232,7 +232,7 @@ mod tests {
     }
 
     fn test_cunningham_chain<const L: usize>(length: usize, num: &Uint<L>) {
-        let mut next = *num;
+        let mut next: Uint<L> = *num;
         for i in 0..length {
             assert!(is_prime(&next));
 
@@ -241,7 +241,7 @@ mod tests {
                 assert!(is_safe_prime(&next));
             }
 
-            next = (next << 1).checked_add(&Uint::<L>::ONE).unwrap();
+            next = (next.shl(1)).checked_add(&Uint::<L>::ONE).unwrap();
         }
 
         // The chain ended.
@@ -265,7 +265,11 @@ mod tests {
             assert!(p.bits_vartime() == bit_length);
             assert!(is_prime(&p));
         }
+    }
 
+    #[test]
+    #[ignore = "Boxed prime generation is not ready"]
+    fn boxed_prime_generation() {
         for bit_length in (28u32..=128).step_by(10) {
             let p: BoxedUint = generate_prime(bit_length, 128);
             assert!(p.bits_vartime() == bit_length);
@@ -280,7 +284,11 @@ mod tests {
             assert!(p.bits_vartime() == bit_length);
             assert!(is_safe_prime(&p));
         }
+    }
 
+    #[test]
+    #[ignore = "Boxed prime generation is not ready"]
+    fn safe_boxed_prime_generation() {
         for bit_length in (28u32..=128).step_by(10) {
             let p: BoxedUint = generate_safe_prime(bit_length, 128);
             assert!(p.bits_vartime() == bit_length);

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -131,7 +131,7 @@ pub fn generate_safe_prime_with_rng<T: UintLike>(
 ///       Math. Comp. 90 1931-1955 (2021),
 ///       DOI: [10.1090/mcom/3616](https://doi.org/10.1090/mcom/3616)
 pub fn is_prime_with_rng<T: UintLike>(rng: &mut impl CryptoRngCore, num: &T) -> bool {
-    if num == &T::from(2u32) {
+    if num == &T::from(2u32).widen(num.bits_precision()) {
         return true;
     }
     if num.is_even().into() {
@@ -148,10 +148,12 @@ pub fn is_safe_prime_with_rng<T: UintLike>(rng: &mut impl CryptoRngCore, num: &T
     // Since, by the definition of safe prime, `(num - 1) / 2` must also be prime,
     // and therefore odd, `num` has to be equal to 3 modulo 4.
     // 5 is the only exception, so we check for it.
-    if num == &T::from(5u32) {
+    if num == &T::from(5u32).widen(num.bits_precision()) {
         return true;
     }
-    if T::from(3u32) & num.clone() != T::from(3u32) {
+    if T::from(3u32).widen(num.bits_precision()) & num.clone()
+        != T::from(3u32).widen(num.bits_precision())
+    {
         return false;
     }
 

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -141,7 +141,7 @@ pub fn is_safe_prime_with_rng<T: UintLike>(rng: &mut impl CryptoRngCore, num: &T
         return false;
     }
 
-    _is_prime_with_rng(rng, num) && _is_prime_with_rng(rng, &num.shr_vartime(1))
+    _is_prime_with_rng(rng, num) && _is_prime_with_rng(rng, &num.shr_vartime(1).0)
 }
 
 /// Checks for primality assuming that `num` is odd.

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -183,7 +183,7 @@ fn _is_prime_with_rng<T: UintLike>(rng: &mut impl CryptoRngCore, num: &T) -> boo
 
 #[cfg(test)]
 mod tests {
-    use crypto_bigint::{CheckedAdd, Uint, Word, U128, U64, BoxedUint};
+    use crypto_bigint::{BoxedUint, CheckedAdd, Uint, Word, U128, U64};
     use num_prime::nt_funcs::is_prime64;
     use rand_core::OsRng;
 

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -10,7 +10,9 @@ use crate::UintLike;
 
 /// Returns a random prime of size `bit_length` using [`OsRng`] as the RNG.
 /// If `bit_length` is `None`, the full size of `Uint<L>` is used.
-/// TODO: bits_precision?
+///
+/// Where T is stack allocated (Uint), `bits_precision` must be exactly `T::BITS`. Where T is
+/// heap-allocated (BoxedUint), `bits_precision` will be passed to the appropriate type.
 ///
 /// See [`is_prime_with_rng`] for details about the performed checks.
 #[cfg(feature = "default-rng")]
@@ -21,7 +23,9 @@ pub fn generate_prime<T: UintLike>(bit_length: u32, bits_precision: u32) -> T {
 /// Returns a random safe prime (that is, such that `(n - 1) / 2` is also prime)
 /// of size `bit_length` using [`OsRng`] as the RNG.
 /// If `bit_length` is `None`, the full size of `Uint<L>` is used.
-/// TODO: bits_precision?
+///
+/// Where T is stack allocated (Uint), `bits_precision` must be exactly `T::BITS`. Where T is
+/// heap-allocated (BoxedUint), `bits_precision` will be passed to the appropriate type.
 ///
 /// See [`is_prime_with_rng`] for details about the performed checks.
 #[cfg(feature = "default-rng")]
@@ -49,7 +53,9 @@ pub fn is_safe_prime<T: UintLike>(num: &T) -> bool {
 
 /// Returns a random prime of size `bit_length` using the provided RNG.
 /// If `bit_length` is `None`, the full size of `Uint<L>` is used.
-/// TODO: bits_precision?
+///
+/// Where T is stack allocated (Uint), `bits_precision` must be exactly `T::BITS`. Where T is
+/// heap-allocated (BoxedUint), `bits_precision` will be passed to the appropriate type.
 ///
 /// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
 ///

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -13,7 +13,7 @@ use crate::UintLike;
 ///
 /// See [`is_prime_with_rng`] for details about the performed checks.
 #[cfg(feature = "default-rng")]
-pub fn generate_prime<T: UintLike>(bit_length: usize) -> T {
+pub fn generate_prime<T: UintLike>(bit_length: u32) -> T {
     generate_prime_with_rng(&mut OsRng, bit_length)
 }
 
@@ -23,7 +23,7 @@ pub fn generate_prime<T: UintLike>(bit_length: usize) -> T {
 ///
 /// See [`is_prime_with_rng`] for details about the performed checks.
 #[cfg(feature = "default-rng")]
-pub fn generate_safe_prime<T: UintLike>(bit_length: usize) -> T {
+pub fn generate_safe_prime<T: UintLike>(bit_length: u32) -> T {
     generate_safe_prime_with_rng(&mut OsRng, bit_length)
 }
 
@@ -51,7 +51,7 @@ pub fn is_safe_prime<T: UintLike>(num: &T) -> bool {
 /// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
 ///
 /// See [`is_prime_with_rng`] for details about the performed checks.
-pub fn generate_prime_with_rng<T: UintLike>(rng: &mut impl CryptoRngCore, bit_length: usize) -> T {
+pub fn generate_prime_with_rng<T: UintLike>(rng: &mut impl CryptoRngCore, bit_length: u32) -> T {
     if bit_length < 2 {
         panic!("`bit_length` must be 2 or greater.");
     }
@@ -75,7 +75,7 @@ pub fn generate_prime_with_rng<T: UintLike>(rng: &mut impl CryptoRngCore, bit_le
 /// See [`is_prime_with_rng`] for details about the performed checks.
 pub fn generate_safe_prime_with_rng<T: UintLike>(
     rng: &mut impl CryptoRngCore,
-    bit_length: usize,
+    bit_length: u32,
 ) -> T {
     if bit_length < 3 {
         panic!("`bit_length` must be 3 or greater.");
@@ -246,7 +246,7 @@ mod tests {
 
     #[test]
     fn prime_generation() {
-        for bit_length in (28..=128).step_by(10) {
+        for bit_length in (28u32..=128).step_by(10) {
             let p: U128 = generate_prime(bit_length);
             assert!(p.bits_vartime() == bit_length);
             assert!(is_prime(&p));
@@ -316,7 +316,7 @@ mod tests {
 
     #[test]
     fn corner_cases_generate_prime() {
-        for bits in 2usize..5 {
+        for bits in 2u32..5 {
             for _ in 0..100 {
                 let p: U64 = generate_prime(bits);
                 let p_word = p.as_words()[0];
@@ -327,7 +327,7 @@ mod tests {
 
     #[test]
     fn corner_cases_generate_safe_prime() {
-        for bits in 3usize..5 {
+        for bits in 3u32..5 {
             for _ in 0..100 {
                 let p: U64 = generate_safe_prime(bits);
                 let p_word = p.as_words()[0];

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -270,7 +270,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Boxed prime generation is not ready"]
     fn boxed_prime_generation() {
         for bit_length in (28u32..=128).step_by(10) {
             let p: BoxedUint = generate_prime(bit_length, 128);
@@ -289,7 +288,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Boxed prime generation is not ready"]
     fn safe_boxed_prime_generation() {
         for bit_length in (28u32..=128).step_by(10) {
             let p: BoxedUint = generate_safe_prime(bit_length, 128);

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -183,7 +183,7 @@ fn _is_prime_with_rng<T: UintLike>(rng: &mut impl CryptoRngCore, num: &T) -> boo
 
 #[cfg(test)]
 mod tests {
-    use crypto_bigint::{CheckedAdd, Uint, Word, U128, U64};
+    use crypto_bigint::{CheckedAdd, Uint, Word, U128, U64, BoxedUint};
     use num_prime::nt_funcs::is_prime64;
     use rand_core::OsRng;
 
@@ -265,12 +265,24 @@ mod tests {
             assert!(p.bits_vartime() == bit_length);
             assert!(is_prime(&p));
         }
+
+        for bit_length in (28u32..=128).step_by(10) {
+            let p: BoxedUint = generate_prime(bit_length, 128);
+            assert!(p.bits_vartime() == bit_length);
+            assert!(is_prime(&p));
+        }
     }
 
     #[test]
     fn safe_prime_generation() {
         for bit_length in (28..=128).step_by(10) {
             let p: U128 = generate_safe_prime(bit_length, U128::BITS);
+            assert!(p.bits_vartime() == bit_length);
+            assert!(is_safe_prime(&p));
+        }
+
+        for bit_length in (28u32..=128).step_by(10) {
+            let p: BoxedUint = generate_safe_prime(bit_length, 128);
             assert!(p.bits_vartime() == bit_length);
             assert!(is_safe_prime(&p));
         }

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -64,7 +64,7 @@ pub fn generate_prime_with_rng<T: UintLike>(
     }
     loop {
         let start = random_odd_uint::<T>(rng, bit_length, bits_precision);
-        let sieve = Sieve::new(&start, bit_length, false);
+        let sieve = Sieve::new(&start, bit_length, false, bits_precision);
         for num in sieve {
             if is_prime_with_rng(rng, &num) {
                 return num;
@@ -90,7 +90,7 @@ pub fn generate_safe_prime_with_rng<T: UintLike>(
     }
     loop {
         let start = random_odd_uint::<T>(rng, bit_length, bits_precision);
-        let sieve = Sieve::new(&start, bit_length, true);
+        let sieve = Sieve::new(&start, bit_length, true, bits_precision);
         for num in sieve {
             if is_safe_prime_with_rng(rng, &num) {
                 return num;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,7 +15,11 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self;
+    fn generate_prime_with_rng(
+        rng: &mut impl CryptoRngCore,
+        bit_length: u32,
+        bits_precision: u32,
+    ) -> Self;
 
     /// Returns a random safe prime (that is, such that `(n - 1) / 2` is also prime)
     /// of size `bit_length` using the provided RNG.
@@ -24,7 +28,11 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 3, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self;
+    fn generate_safe_prime_with_rng(
+        rng: &mut impl CryptoRngCore,
+        bit_length: u32,
+        bits_precision: u32,
+    ) -> Self;
 
     /// Checks probabilistically if the given number is prime using the provided RNG.
     ///
@@ -38,11 +46,19 @@ pub trait RandomPrimeWithRng {
 }
 
 impl<const L: usize> RandomPrimeWithRng for Uint<L> {
-    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
-        generate_prime_with_rng(rng, bit_length)
+    fn generate_prime_with_rng(
+        rng: &mut impl CryptoRngCore,
+        bit_length: u32,
+        bits_precision: u32,
+    ) -> Self {
+        generate_prime_with_rng(rng, bit_length, bits_precision)
     }
-    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
-        generate_safe_prime_with_rng(rng, bit_length)
+    fn generate_safe_prime_with_rng(
+        rng: &mut impl CryptoRngCore,
+        bit_length: u32,
+        bits_precision: u32,
+    ) -> Self {
+        generate_safe_prime_with_rng(rng, bit_length, bits_precision)
     }
     fn is_prime_with_rng(&self, rng: &mut impl CryptoRngCore) -> bool {
         is_prime_with_rng(rng, self)
@@ -67,9 +83,10 @@ mod tests {
         assert!(!U64::from(13u32).is_safe_prime_with_rng(&mut OsRng));
         assert!(U64::from(11u32).is_safe_prime_with_rng(&mut OsRng));
 
-        assert!(U64::generate_prime_with_rng(&mut OsRng, 10).is_prime_with_rng(&mut OsRng));
         assert!(
-            U64::generate_safe_prime_with_rng(&mut OsRng, 10).is_safe_prime_with_rng(&mut OsRng)
+            U64::generate_prime_with_rng(&mut OsRng, 10, U64::BITS).is_prime_with_rng(&mut OsRng)
         );
+        assert!(U64::generate_safe_prime_with_rng(&mut OsRng, 10, U64::BITS)
+            .is_safe_prime_with_rng(&mut OsRng));
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,7 +15,7 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self;
+    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self;
 
     /// Returns a random safe prime (that is, such that `(n - 1) / 2` is also prime)
     /// of size `bit_length` using the provided RNG.
@@ -24,7 +24,7 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 3, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self;
+    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self;
 
     /// Checks probabilistically if the given number is prime using the provided RNG.
     ///
@@ -38,10 +38,10 @@ pub trait RandomPrimeWithRng {
 }
 
 impl<const L: usize> RandomPrimeWithRng for Uint<L> {
-    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self {
+    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
         generate_prime_with_rng(rng, bit_length)
     }
-    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self {
+    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
         generate_safe_prime_with_rng(rng, bit_length)
     }
     fn is_prime_with_rng(&self, rng: &mut impl CryptoRngCore) -> bool {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,7 +15,7 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<usize>) -> Self;
+    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self;
 
     /// Returns a random safe prime (that is, such that `(n - 1) / 2` is also prime)
     /// of size `bit_length` using the provided RNG.
@@ -24,10 +24,7 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 3, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn generate_safe_prime_with_rng(
-        rng: &mut impl CryptoRngCore,
-        bit_length: Option<usize>,
-    ) -> Self;
+    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self;
 
     /// Checks probabilistically if the given number is prime using the provided RNG.
     ///
@@ -41,13 +38,10 @@ pub trait RandomPrimeWithRng {
 }
 
 impl<const L: usize> RandomPrimeWithRng for Uint<L> {
-    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<usize>) -> Self {
+    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self {
         generate_prime_with_rng(rng, bit_length)
     }
-    fn generate_safe_prime_with_rng(
-        rng: &mut impl CryptoRngCore,
-        bit_length: Option<usize>,
-    ) -> Self {
+    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self {
         generate_safe_prime_with_rng(rng, bit_length)
     }
     fn is_prime_with_rng(&self, rng: &mut impl CryptoRngCore) -> bool {
@@ -73,8 +67,9 @@ mod tests {
         assert!(!U64::from(13u32).is_safe_prime_with_rng(&mut OsRng));
         assert!(U64::from(11u32).is_safe_prime_with_rng(&mut OsRng));
 
-        assert!(U64::generate_prime_with_rng(&mut OsRng, Some(10)).is_prime_with_rng(&mut OsRng));
-        assert!(U64::generate_safe_prime_with_rng(&mut OsRng, Some(10))
-            .is_safe_prime_with_rng(&mut OsRng));
+        assert!(U64::generate_prime_with_rng(&mut OsRng, 10).is_prime_with_rng(&mut OsRng));
+        assert!(
+            U64::generate_safe_prime_with_rng(&mut OsRng, 10).is_safe_prime_with_rng(&mut OsRng)
+        );
     }
 }

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -66,6 +66,8 @@ pub trait UintModLike:
     fn one(params: &Self::Params) -> Self;
     fn square(&self) -> Self;
     fn div_by_2(&self) -> Self;
+
+    fn refresh(&self) -> Self;
 }
 
 /// Uint<L> impls
@@ -177,6 +179,10 @@ impl<const L: usize> UintModLike for DynResidue<L> {
 
     fn div_by_2(&self) -> Self {
         Self::div_by_2(self)
+    }
+
+    fn refresh(&self) -> Self {
+        *self
     }
 }
 
@@ -342,5 +348,12 @@ impl UintModLike for BoxedResidue {
     /// TODO: BoxedUint does not implement div_by_2
     fn div_by_2(&self) -> Self {
         self.div_by_2()
+    }
+
+    // TODO: BoxedResidue::square might be buggy
+    // Check https://github.com/RustCrypto/crypto-bigint/issues/441 for details
+    // Calling "retrieve" and reinstantiate seems to help
+    fn refresh(&self) -> Self {
+        Self::new(self.retrieve(), self.params().clone())
     }
 }

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -119,7 +119,7 @@ impl<const L: usize> UintLike for Uint<L> {
     }
 
     fn ct_div_rem_limb_with_reciprocal(&self, reciprocal: &Reciprocal) -> (Self, Limb) {
-        Self::ct_div_rem_limb_with_reciprocal(self, reciprocal)
+        self.div_rem_limb_with_reciprocal(reciprocal)
     }
 
     fn try_into_u32(&self) -> Option<u32> {

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -103,11 +103,11 @@ impl<const L: usize> UintLike for Uint<L> {
     }
 
     fn shr_vartime(&self, shift: u32) -> (Self, ConstChoice) {
-        Self::shr_vartime(self, shift)
+        Self::overflowing_shr_vartime(self, shift)
     }
 
     fn shl_vartime(&self, shift: u32) -> (Self, ConstChoice) {
-        Self::shl_vartime(self, shift)
+        Self::overflowing_shl_vartime(self, shift)
     }
 
     fn as_limbs(&self) -> &[Limb] {

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -1,4 +1,4 @@
-use core::ops::{Add, BitOr, BitOrAssign, Mul, Neg, Sub};
+use core::ops::{Add, BitAnd, BitOr, BitOrAssign, Mul, Neg, Sub};
 
 use crypto_bigint::{
     modular::{DynResidue, DynResidueParams},
@@ -17,6 +17,7 @@ pub trait UintLike:
     + for<'a> CheckedAdd<&'a Self>
     + Zero
     + BitOr<Output = Self>
+    + for<'a> BitAnd<&'a Self, Output = Self>
     + BitOrAssign
     + RandomMod
 {

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -109,11 +109,29 @@ impl<const L: usize> UintLike for Uint<L> {
     }
 
     fn shr_vartime(&self, shift: u32) -> (Self, ConstChoice) {
-        Self::overflowing_shr_vartime(self, shift)
+        let opt = self.overflowing_shr_vartime(shift);
+        if opt.is_none().into() {
+            // opt.is_none() indicates overflow
+            (Self::ZERO, ConstChoice::TRUE)
+        } else {
+            (
+                opt.expect("attempt to right shift with overflow"),
+                ConstChoice::FALSE,
+            )
+        }
     }
 
     fn shl_vartime(&self, shift: u32) -> (Self, ConstChoice) {
-        Self::overflowing_shl_vartime(self, shift)
+        let opt = self.overflowing_shl_vartime(shift);
+        if opt.is_none().into() {
+            // opt.is_none() indicates overflow
+            (Self::ZERO, ConstChoice::TRUE)
+        } else {
+            (
+                opt.expect("attempt to left shift with overflow"),
+                ConstChoice::FALSE,
+            )
+        }
     }
 
     fn as_limbs(&self) -> &[Limb] {

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -1,10 +1,13 @@
+use crate::hazmat::{
+    gcd::gcd,
+    jacobi::{self, JacobiSymbol},
+};
 use core::ops::{Add, Mul, Neg, Sub};
-use crate::hazmat::jacobi::{self, JacobiSymbol};
 
 use crypto_bigint::{
     modular::{DynResidue, DynResidueParams},
     subtle::CtOption,
-    ConstChoice, Integer, Limb, NonZero, PowBoundedExp, RandomMod, Reciprocal, Uint,
+    ConstChoice, Integer, Limb, NonZero, PowBoundedExp, RandomMod, Reciprocal, Uint, Word,
 };
 use rand_core::CryptoRngCore;
 
@@ -30,6 +33,7 @@ pub trait UintLike: Integer + RandomMod {
     fn try_into_u32(&self) -> Option<u32>; // Will have to be implemented at Uint<L> level if we want to use TryFrom trait
 
     fn as_limbs(&self) -> &[Limb];
+    fn as_words(&self) -> &[Word];
     fn div_rem_limb(&self, rhs: NonZero<Limb>) -> (Self, Limb);
 }
 
@@ -61,13 +65,16 @@ pub trait UintModLike:
 impl<const L: usize> UintLike for Uint<L> {
     type Modular = DynResidue<L>;
 
+    fn as_words(&self) -> &[Word] {
+        self.as_words()
+    }
+
     fn jacobi_symbol_small(lhs: i32, rhs: &Self) -> JacobiSymbol {
         jacobi::jacobi_symbol(lhs, rhs)
     }
 
-    #[allow(unused_variables)]
     fn gcd_small(&self, rhs: u32) -> u32 {
-        unimplemented!()
+        gcd(self, rhs)
     }
 
     fn trailing_zeros(&self) -> u32 {

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -8,15 +8,13 @@ use crypto_bigint::{
 use rand_core::CryptoRngCore;
 
 // would be nice to have: *Assign traits; arithmetic traits for &self (BitAnd and Shr in particular);
-pub trait UintLike: Integer + From<u32> + From<u16> + RandomMod {
+pub trait UintLike: Integer + RandomMod {
     type Modular: UintModLike<Raw = Self>;
 
     // We can get by with non-small versions of jacobi_symbol and gcd, they don't have a big impact
     // on the performance.
     fn jacobi_symbol_small(lhs: i32, rhs: &Self) -> JacobiSymbol;
     fn gcd_small(&self, rhs: u32) -> u32;
-    fn bits(&self) -> u32;
-    fn bits_vartime(&self) -> u32;
     fn bit_vartime(&self, index: u32) -> bool;
     fn trailing_zeros(&self) -> u32;
     fn trailing_ones(&self) -> u32;
@@ -98,14 +96,6 @@ impl<const L: usize> UintLike for Uint<L> {
 
     fn wrapping_mul(&self, rhs: &Self) -> Self {
         Self::wrapping_mul(self, rhs)
-    }
-
-    fn bits(&self) -> u32 {
-        Self::bits(self)
-    }
-
-    fn bits_vartime(&self) -> u32 {
-        Self::bits_vartime(self)
     }
 
     fn bit_vartime(&self, index: u32) -> bool {

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -312,7 +312,7 @@ impl UintModLike for BoxedResidue {
     }
 
     fn new(raw: &Self::Raw, params: &Self::Params) -> Self {
-        Self::new(raw.clone(), params.clone())
+        Self::new(raw.widen(params.bits_precision()).clone(), params.clone())
     }
 
     fn zero(params: &Self::Params) -> Self {

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -7,8 +7,7 @@ use core::ops::{Add, Mul, Neg, Sub};
 use crypto_bigint::{
     modular::{DynResidue, DynResidueParams},
     subtle::CtOption,
-    ConstChoice, Integer, Limb, NonZero, PowBoundedExp, RandomMod, Reciprocal, Uint, Word,
-    Random
+    ConstChoice, Integer, Limb, NonZero, PowBoundedExp, Random, RandomMod, Reciprocal, Uint, Word,
 };
 use rand_core::CryptoRngCore;
 
@@ -115,7 +114,9 @@ impl<const L: usize> UintLike for Uint<L> {
     }
 
     fn random_bits(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
-        Self::random(rng).shl(Self::BITS - bit_length).0
+        let random = Self::random(rng) & Self::MAX >> (Self::BITS - bit_length);
+        let random = random | Self::ONE << (bit_length - 1);
+        return random;
     }
 
     fn ct_div_rem_limb_with_reciprocal(&self, reciprocal: &Reciprocal) -> (Self, Limb) {

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -2,35 +2,30 @@ use core::ops::{Add, Mul, Neg, Sub};
 
 use crypto_bigint::{
     modular::{DynResidue, DynResidueParams},
-    subtle::{CtOption},
+    subtle::CtOption,
     Integer, Limb, PowBoundedExp, RandomMod, Reciprocal, Uint,
 };
 use rand_core::CryptoRngCore;
 
 // would be nice to have: *Assign traits; arithmetic traits for &self (BitAnd and Shr in particular);
-pub trait UintLike:
-    Integer
-    + From<u32>
-    + From<u16>
-    + RandomMod
-{
+pub trait UintLike: Integer + From<u32> + From<u16> + RandomMod {
     type Modular: UintModLike<Raw = Self>;
 
     // We can get by with non-small versions of jacobi_symbol and gcd, they don't have a big impact
     // on the performance.
     fn jacobi_symbol_small(lhs: i32, rhs: &Self) -> JacobiSymbol;
     fn gcd_small(&self, rhs: u32) -> u32;
-    fn bits(&self) -> usize;
-    fn bits_vartime(&self) -> usize;
-    fn bit_vartime(&self, index: usize) -> bool;
-    fn trailing_zeros(&self) -> usize;
-    fn trailing_ones(&self) -> usize;
+    fn bits(&self) -> u32;
+    fn bits_vartime(&self) -> u32;
+    fn bit_vartime(&self, index: u32) -> bool;
+    fn trailing_zeros(&self) -> u32;
+    fn trailing_ones(&self) -> u32;
     fn wrapping_sub(&self, rhs: &Self) -> Self;
     fn wrapping_mul(&self, rhs: &Self) -> Self;
     fn sqrt_vartime(&self) -> Self;
-    fn shr_vartime(&self, shift: usize) -> Self;
-    fn shl_vartime(&self, shift: usize) -> Self;
-    fn random_bits(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self;
+    fn shr_vartime(&self, shift: u32) -> Self;
+    fn shl_vartime(&self, shift: u32) -> Self;
+    fn random_bits(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self;
     fn ct_div_rem_limb_with_reciprocal(&self, reciprocal: &Reciprocal) -> (Self, Limb);
     fn try_into_u32(&self) -> Option<u32>; // Will have to be implemented at Uint<L> level if we want to use TryFrom trait
 }
@@ -89,11 +84,11 @@ impl<const L: usize> UintLike for Uint<L> {
         unimplemented!()
     }
 
-    fn trailing_zeros(&self) -> usize {
+    fn trailing_zeros(&self) -> u32 {
         Self::trailing_zeros(self)
     }
 
-    fn trailing_ones(&self) -> usize {
+    fn trailing_ones(&self) -> u32 {
         Self::trailing_ones(self)
     }
 
@@ -105,15 +100,15 @@ impl<const L: usize> UintLike for Uint<L> {
         Self::wrapping_mul(self, rhs)
     }
 
-    fn bits(&self) -> usize {
+    fn bits(&self) -> u32 {
         Self::bits(self)
     }
 
-    fn bits_vartime(&self) -> usize {
+    fn bits_vartime(&self) -> u32 {
         Self::bits_vartime(self)
     }
 
-    fn bit_vartime(&self, index: usize) -> bool {
+    fn bit_vartime(&self, index: u32) -> bool {
         Self::bit_vartime(self, index)
     }
 
@@ -121,15 +116,15 @@ impl<const L: usize> UintLike for Uint<L> {
         Self::sqrt_vartime(self)
     }
 
-    fn shr_vartime(&self, shift: usize) -> Self {
+    fn shr_vartime(&self, shift: u32) -> Self {
         Self::shr_vartime(self, shift)
     }
 
-    fn shl_vartime(&self, shift: usize) -> Self {
+    fn shl_vartime(&self, shift: u32) -> Self {
         Self::shl_vartime(self, shift)
     }
 
-    fn random_bits(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self {
+    fn random_bits(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
         unimplemented!()
     }
 

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -114,7 +114,7 @@ impl<const L: usize> UintLike for Uint<L> {
         self.as_limbs()
     }
 
-    fn random_bits(rng: &mut impl CryptoRngCore, bit_length: u32, bits_precision: u32) -> Self {
+    fn random_bits(rng: &mut impl CryptoRngCore, bit_length: u32, _bits_precision: u32) -> Self {
         let random = Self::random(rng) & Self::MAX >> (Self::BITS - bit_length);
         let random = random | Self::ONE << (bit_length - 1);
         return random;
@@ -224,33 +224,19 @@ impl UintLike for BoxedUint {
 
     /// BoxedUint does not implement sqrt_vartime
     fn sqrt_vartime(&self) -> Self {
-        todo!();
+        self.sqrt_vartime()
     }
 
     /// TODO: BoxedUint::shr_vartime should behave similarly as Uint::shr_vartime; instead of
     /// returning Option, return (val, choice)
     fn shr_vartime(&self, shift: u32) -> (Self, ConstChoice) {
-        if let Some(shifted) = self.shr_vartime(shift) {
-            return (shifted, ConstChoice::FALSE);
-        } else {
-            return (
-                Self::zero_with_precision(self.bits_precision()),
-                ConstChoice::TRUE,
-            );
-        }
+        self.shr_vartime(shift)
     }
 
     /// TODO: BoxedUint::shl_vartime should behave similarly as Uint::shr_vartime; instead of
     /// returning Option, return (val, choice)
     fn shl_vartime(&self, shift: u32) -> (Self, ConstChoice) {
-        if let Some(shifted) = self.shl_vartime(shift) {
-            return (shifted, ConstChoice::FALSE);
-        } else {
-            return (
-                Self::zero_with_precision(self.bits_precision()),
-                ConstChoice::TRUE,
-            );
-        }
+        self.shl_vartime(shift)
     }
 
     fn random_bits(rng: &mut impl CryptoRngCore, bit_length: u32, bits_precision: u32) -> Self {
@@ -263,7 +249,7 @@ impl UintLike for BoxedUint {
     /// TODO: BoxedUint does not implement div_rem_limb_with_reciprocal
     /// TODO: BoxedUint does not implement shl_limb
     fn ct_div_rem_limb_with_reciprocal(&self, reciprocal: &Reciprocal) -> (Self, Limb) {
-        todo!();
+        self.div_rem_limb_with_reciprocal(reciprocal)
     }
 
     fn try_into_u32(&self) -> Option<u32> {
@@ -280,7 +266,7 @@ impl UintLike for BoxedUint {
 
     /// TODO: BoxedUint does not implement div_rem_limb
     fn div_rem_limb(&self, rhs: NonZero<Limb>) -> (Self, Limb) {
-        todo!();
+        self.div_rem_limb(rhs)
     }
 }
 

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -329,6 +329,6 @@ impl UintModLike for BoxedResidue {
 
     /// TODO: BoxedUint does not implement div_by_2
     fn div_by_2(&self) -> Self {
-        todo!();
+        self.div_by_2()
     }
 }

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -36,6 +36,8 @@ pub trait UintLike: Integer + RandomMod {
     fn as_limbs(&self) -> &[Limb];
     fn as_words(&self) -> &[Word];
     fn div_rem_limb(&self, rhs: NonZero<Limb>) -> (Self, Limb);
+    fn one_with_precision(bits_precision: u32) -> Self;
+    fn zero_with_precision(bits_precision: u32) -> Self;
 }
 
 #[allow(missing_docs)]
@@ -130,6 +132,14 @@ impl<const L: usize> UintLike for Uint<L> {
 
     fn div_rem_limb(&self, rhs: NonZero<Limb>) -> (Self, Limb) {
         self.div_rem_limb(rhs)
+    }
+
+    fn one_with_precision(_bits_precision: u32) -> Self {
+        Self::ONE
+    }
+
+    fn zero_with_precision(_bits_precision: u32) -> Self {
+        Self::ZERO
     }
 }
 
@@ -282,6 +292,14 @@ impl UintLike for BoxedUint {
     /// TODO: BoxedUint does not implement div_rem_limb
     fn div_rem_limb(&self, rhs: NonZero<Limb>) -> (Self, Limb) {
         self.div_rem_limb(rhs)
+    }
+
+    fn one_with_precision(bits_precision: u32) -> Self {
+        Self::one_with_precision(bits_precision)
+    }
+
+    fn zero_with_precision(bits_precision: u32) -> Self {
+        Self::zero_with_precision(bits_precision)
     }
 }
 

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -5,9 +5,10 @@ use crate::hazmat::{
 use core::ops::{Add, Mul, Neg, Sub};
 
 use crypto_bigint::{
-    modular::{DynResidue, DynResidueParams},
+    modular::{BoxedResidue, BoxedResidueParams, DynResidue, DynResidueParams},
     subtle::CtOption,
-    ConstChoice, Integer, Limb, NonZero, PowBoundedExp, Random, RandomMod, Reciprocal, Uint, Word,
+    BoxedUint, ConstChoice, Integer, Limb, NonZero, PowBoundedExp, Random, RandomMod, Reciprocal,
+    Uint, Word,
 };
 use rand_core::CryptoRngCore;
 
@@ -158,5 +159,102 @@ impl<const L: usize> UintModLike for DynResidue<L> {
 
     fn div_by_2(&self) -> Self {
         Self::div_by_2(self)
+    }
+}
+
+impl UintLike for BoxedUint {
+    type Modular = BoxedResidue;
+
+    fn jacobi_symbol_small(lhs: i32, rhs: &Self) -> JacobiSymbol {
+        todo!();
+    }
+
+    fn gcd_small(&self, rhs: u32) -> u32 {
+        todo!();
+    }
+
+    fn bit_vartime(&self, index: u32) -> bool {
+        todo!();
+    }
+
+    fn trailing_zeros(&self) -> u32 {
+        todo!();
+    }
+
+    fn trailing_ones(&self) -> u32 {
+        todo!();
+    }
+
+    fn wrapping_sub(&self, rhs: &Self) -> Self {
+        todo!();
+    }
+
+    fn wrapping_mul(&self, rhs: &Self) -> Self {
+        todo!();
+    }
+
+    fn sqrt_vartime(&self) -> Self {
+        todo!();
+    }
+
+    fn shr_vartime(&self, shift: u32) -> (Self, ConstChoice) {
+        todo!();
+    }
+
+    fn shl_vartime(&self, shift: u32) -> (Self, ConstChoice) {
+        todo!();
+    }
+
+    fn random_bits(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
+        todo!();
+    }
+
+    fn ct_div_rem_limb_with_reciprocal(&self, reciprocal: &Reciprocal) -> (Self, Limb) {
+        todo!();
+    }
+
+    fn try_into_u32(&self) -> Option<u32> {
+        todo!();
+    }
+
+    fn as_limbs(&self) -> &[Limb] {
+        todo!();
+    }
+
+    fn as_words(&self) -> &[Word] {
+        todo!();
+    }
+
+    fn div_rem_limb(&self, rhs: NonZero<Limb>) -> (Self, Limb) {
+        todo!();
+    }
+}
+
+impl UintModLike for BoxedResidue {
+    type Raw = BoxedUint;
+    type Params = BoxedResidueParams;
+
+    fn new_params(modulus: &Self::Raw) -> CtOption<Self::Params> {
+        todo!();
+    }
+
+    fn new(raw: &Self::Raw, params: &Self::Params) -> Self {
+        todo!();
+    }
+
+    fn zero(params: &Self::Params) -> Self {
+        todo!();
+    }
+
+    fn one(params: &Self::Params) -> Self {
+        todo!();
+    }
+
+    fn square(&self) -> Self {
+        todo!();
+    }
+
+    fn div_by_2(&self) -> Self {
+        todo!();
     }
 }

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -1,0 +1,145 @@
+use core::ops::{Add, Mul, Neg, Sub};
+
+use crypto_bigint::{
+    modular::{DynResidue, DynResidueParams},
+    subtle::{Choice, CtOption},
+    CheckedAdd, Integer, Uint, Zero,
+};
+
+pub trait UintLike:
+    Clone + core::fmt::Debug + Eq + From<u32> + Ord + for<'a> CheckedAdd<&'a Self> + Zero
+{
+    type Modular: UintModLike<Raw = Self>;
+
+    // We can get by with non-small versions of jacobi_symbol and gcd, they don't have a big impact
+    // on the performance.
+    fn jacobi_symbol_small(lhs: i32, rhs: &Self) -> JacobiSymbol;
+    fn gcd_small(&self, rhs: u32) -> u32;
+    fn bits_vartime(&self) -> usize;
+    fn bit_vartime(&self, index: usize) -> bool;
+    fn trailing_ones(&self) -> usize;
+    fn wrapping_mul(&self, rhs: &Self) -> Self;
+    fn sqrt_vartime(&self) -> Self;
+    fn is_even(&self) -> Choice;
+    fn is_odd(&self) -> Choice;
+    fn shr(&self, shift: usize) -> Self;
+    fn one() -> Self;
+}
+
+pub trait UintModLike:
+    Clone
+    + Eq
+    + Sized
+    + for<'a> Add<&'a Self, Output = Self>
+    + for<'a> Sub<&'a Self, Output = Self>
+    + for<'a> Mul<&'a Self, Output = Self>
+    + Neg<Output = Self>
+{
+    type Raw: UintLike<Modular = Self>;
+    type Params;
+
+    fn new_params(modulus: &Self::Raw) -> CtOption<Self::Params>;
+    fn new(raw: &Self::Raw, params: &Self::Params) -> Self;
+
+    fn zero(params: &Self::Params) -> Self;
+    fn one(params: &Self::Params) -> Self;
+    fn square(&self) -> Self;
+    fn div_by_2(&self) -> Self;
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum JacobiSymbol {
+    Zero,
+    One,
+    MinusOne,
+}
+
+impl Neg for JacobiSymbol {
+    type Output = Self;
+    fn neg(self) -> Self {
+        match self {
+            Self::Zero => Self::Zero,
+            Self::One => Self::MinusOne,
+            Self::MinusOne => Self::One,
+        }
+    }
+}
+
+// Uint<L> impls
+
+impl<const L: usize> UintLike for Uint<L> {
+    type Modular = DynResidue<L>;
+
+    fn jacobi_symbol_small(lhs: i32, rhs: &Self) -> JacobiSymbol {
+        unimplemented!()
+    }
+
+    fn gcd_small(&self, rhs: u32) -> u32 {
+        unimplemented!()
+    }
+
+    fn trailing_ones(&self) -> usize {
+        Self::trailing_ones(self)
+    }
+
+    fn wrapping_mul(&self, rhs: &Self) -> Self {
+        Self::wrapping_mul(self, rhs)
+    }
+
+    fn bits_vartime(&self) -> usize {
+        Self::bits_vartime(self)
+    }
+
+    fn bit_vartime(&self, index: usize) -> bool {
+        Self::bit_vartime(self, index)
+    }
+
+    fn sqrt_vartime(&self) -> Self {
+        Self::sqrt_vartime(self)
+    }
+
+    fn is_even(&self) -> Choice {
+        Integer::is_even(self)
+    }
+
+    fn is_odd(&self) -> Choice {
+        Integer::is_odd(self)
+    }
+
+    fn shr(&self, shift: usize) -> Self {
+        Self::shr(self, shift)
+    }
+
+    fn one() -> Self {
+        Self::ONE
+    }
+}
+
+impl<const L: usize> UintModLike for DynResidue<L> {
+    type Raw = Uint<L>;
+    type Params = DynResidueParams<L>;
+
+    fn new_params(modulus: &Self::Raw) -> CtOption<Self::Params> {
+        Self::Params::new(modulus)
+    }
+
+    fn new(value: &Self::Raw, params: &Self::Params) -> Self {
+        Self::new(value, *params)
+    }
+
+    fn zero(params: &Self::Params) -> Self {
+        Self::zero(*params)
+    }
+
+    fn one(precomputed: &Self::Params) -> Self {
+        Self::one(*precomputed)
+    }
+
+    fn square(&self) -> Self {
+        Self::square(self)
+    }
+
+    fn div_by_2(&self) -> Self {
+        Self::div_by_2(self)
+    }
+}

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -66,8 +66,6 @@ pub trait UintModLike:
     fn one(params: &Self::Params) -> Self;
     fn square(&self) -> Self;
     fn div_by_2(&self) -> Self;
-
-    fn refresh(&self) -> Self;
 }
 
 /// Uint<L> impls
@@ -179,10 +177,6 @@ impl<const L: usize> UintModLike for DynResidue<L> {
 
     fn div_by_2(&self) -> Self {
         Self::div_by_2(self)
-    }
-
-    fn refresh(&self) -> Self {
-        *self
     }
 }
 
@@ -348,12 +342,5 @@ impl UintModLike for BoxedResidue {
     /// TODO: BoxedUint does not implement div_by_2
     fn div_by_2(&self) -> Self {
         self.div_by_2()
-    }
-
-    // TODO: BoxedResidue::square might be buggy
-    // Check https://github.com/RustCrypto/crypto-bigint/issues/441 for details
-    // Calling "retrieve" and reinstantiate seems to help
-    fn refresh(&self) -> Self {
-        Self::new(self.retrieve(), self.params().clone())
     }
 }

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -36,8 +36,12 @@ pub trait UintLike: Integer + RandomMod {
     fn as_limbs(&self) -> &[Limb];
     fn as_words(&self) -> &[Word];
     fn div_rem_limb(&self, rhs: NonZero<Limb>) -> (Self, Limb);
+
+    // This is necessary for making sure that every BoxedUint has the same bits_precision
+    // TODO: remove them after BoxedUint can work with different bits_precision
     fn one_with_precision(bits_precision: u32) -> Self;
     fn zero_with_precision(bits_precision: u32) -> Self;
+    fn widen(&self, bits_precision: u32) -> Self;
 }
 
 #[allow(missing_docs)]
@@ -140,6 +144,10 @@ impl<const L: usize> UintLike for Uint<L> {
 
     fn zero_with_precision(_bits_precision: u32) -> Self {
         Self::ZERO
+    }
+
+    fn widen(&self, _bits_precision: u32) -> Self {
+        *self
     }
 }
 
@@ -300,6 +308,10 @@ impl UintLike for BoxedUint {
 
     fn zero_with_precision(bits_precision: u32) -> Self {
         Self::zero_with_precision(bits_precision)
+    }
+
+    fn widen(&self, bits_precision: u32) -> Self {
+        self.widen(bits_precision)
     }
 }
 

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -1,24 +1,17 @@
-use core::ops::{Add, BitAnd, BitOr, BitOrAssign, Mul, Neg, Sub};
+use core::ops::{Add, Mul, Neg, Sub};
 
 use crypto_bigint::{
     modular::{DynResidue, DynResidueParams},
-    subtle::{Choice, CtOption},
-    CheckedAdd, Integer, Limb, PowBoundedExp, RandomMod, Reciprocal, Uint, Zero,
+    subtle::{CtOption},
+    Integer, Limb, PowBoundedExp, RandomMod, Reciprocal, Uint,
 };
 use rand_core::CryptoRngCore;
 
+// would be nice to have: *Assign traits; arithmetic traits for &self (BitAnd and Shr in particular);
 pub trait UintLike:
-    Clone
-    + core::fmt::Debug
-    + Eq
+    Integer
     + From<u32>
     + From<u16>
-    + Ord
-    + for<'a> CheckedAdd<&'a Self>
-    + Zero
-    + BitOr<Output = Self>
-    + for<'a> BitAnd<&'a Self, Output = Self>
-    + BitOrAssign
     + RandomMod
 {
     type Modular: UintModLike<Raw = Self>;
@@ -35,13 +28,8 @@ pub trait UintLike:
     fn wrapping_sub(&self, rhs: &Self) -> Self;
     fn wrapping_mul(&self, rhs: &Self) -> Self;
     fn sqrt_vartime(&self) -> Self;
-    fn is_even(&self) -> Choice;
-    fn is_odd(&self) -> Choice;
-    fn shr(&self, shift: usize) -> Self;
     fn shr_vartime(&self, shift: usize) -> Self;
-    fn shl(&self, shift: usize) -> Self;
     fn shl_vartime(&self, shift: usize) -> Self;
-    fn one() -> Self;
     fn random_bits(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self;
     fn ct_div_rem_limb_with_reciprocal(&self, reciprocal: &Reciprocal) -> (Self, Limb);
     fn try_into_u32(&self) -> Option<u32>; // Will have to be implemented at Uint<L> level if we want to use TryFrom trait
@@ -133,32 +121,12 @@ impl<const L: usize> UintLike for Uint<L> {
         Self::sqrt_vartime(self)
     }
 
-    fn is_even(&self) -> Choice {
-        Integer::is_even(self)
-    }
-
-    fn is_odd(&self) -> Choice {
-        Integer::is_odd(self)
-    }
-
-    fn shr(&self, shift: usize) -> Self {
-        Self::shr(self, shift)
-    }
-
     fn shr_vartime(&self, shift: usize) -> Self {
         Self::shr_vartime(self, shift)
     }
 
-    fn shl(&self, shift: usize) -> Self {
-        Self::shl(self, shift)
-    }
-
     fn shl_vartime(&self, shift: usize) -> Self {
         Self::shl_vartime(self, shift)
-    }
-
-    fn one() -> Self {
-        Self::ONE
     }
 
     fn random_bits(rng: &mut impl CryptoRngCore, bit_length: usize) -> Self {

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -8,6 +8,7 @@ use crypto_bigint::{
     modular::{DynResidue, DynResidueParams},
     subtle::CtOption,
     ConstChoice, Integer, Limb, NonZero, PowBoundedExp, RandomMod, Reciprocal, Uint, Word,
+    Random
 };
 use rand_core::CryptoRngCore;
 
@@ -113,9 +114,8 @@ impl<const L: usize> UintLike for Uint<L> {
         self.as_limbs()
     }
 
-    #[allow(unused_variables)]
     fn random_bits(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
-        unimplemented!()
+        Self::random(rng).shl(Self::BITS - bit_length).0
     }
 
     fn ct_div_rem_limb_with_reciprocal(&self, reciprocal: &Reciprocal) -> (Self, Limb) {


### PR DESCRIPTION
This PR is a continuation of #36 (and thus is a halfway point to #34), though it is still WIP.

#36 in its current state will not compile. There are many `unimplemented!()`. Some of the API's from `crypto-bigint` has also changed.

This PR improves on #36 by:

- [x] Completing the implementation of `jacobi_small` and `gcd_small`, which includes transitioning `hazmat::jacobi` and `hazmat::gcd` to be implemented using `<T: UintLike>` instead of `Uint<L>`
- [x] Implement random_bits correctly
- [x] Try implement `UintLike` for `BoxedUint`
- [x] Write test cases and bench marks for prime generation using `BoxedUint`

As of `ba9d3c5633020e7b50e5569e6ddb8e831fbd3d2c` the crate will compile, but not all tests will pass: