### PR TITLE
Bump `crypto-bigint` to 0.6.0-pre.5

### DIFF
--- a/.github/workflows/crypto-primes.yml
+++ b/.github/workflows/crypto-primes.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.73.0 # MSRV
           - stable
         target:
           - wasm32-unknown-unknown
@@ -134,6 +134,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.65.0
+          toolchain: 1.73.0
           profile: minimal
       - run: cargo build --all-features --benches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped `crypto-bigint` to 0.6.0-pre.5. ([#38])
 - Bumped MSRV to 1.73. (#[38])
-- `MillerRabin::new()` takes an `Odd`-wrapped integer by value. `random_odd_uint()` returns an `Odd`-wrapped integer. `LucasBase::generate()` takes an `Odd`-wrapped integer. (#[38])
+- `MillerRabin::new()` takes an `Odd`-wrapped integer by value. `random_odd_uint()` returns an `Odd`-wrapped integer. `LucasBase::generate()` takes an `Odd`-wrapped integer. `lucas_test` takes an `Odd`-wrapped integer. (#[38])
 - All bit length-type parameters take `u32` instead of `usize`. (#[38])
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.5.1] - Unreleased
+## [0.6.0-pre.0] - Unreleased
 
-### Fixed
+### Changed
 
-- Bumped `crypto-bigint` to 0.5.4. ([#35])
+- Bumped `crypto-bigint` to 0.6.0-pre.5. ([#38])
+- Bumped MSRV to 1.73. (#[38])
+- `MillerRabin::new()` takes an `Odd`-wrapped integer by value. `random_odd_uint()` returns an `Odd`-wrapped integer. (#[38])
+- All bit length-type parameters take `u32` instead of `usize`. (#[38])
 
 
-[#35]: https://github.com/entropyxyz/crypto-primes/pull/35
+[#35]: https://github.com/entropyxyz/crypto-primes/pull/38
 
 
 ## [0.5.0] - 2023-08-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped `crypto-bigint` to 0.6.0-pre.5. ([#38])
 - Bumped MSRV to 1.73. (#[38])
-- `MillerRabin::new()` takes an `Odd`-wrapped integer by value. `random_odd_uint()` returns an `Odd`-wrapped integer. (#[38])
+- `MillerRabin::new()` takes an `Odd`-wrapped integer by value. `random_odd_uint()` returns an `Odd`-wrapped integer. `LucasBase::generate()` takes an `Odd`-wrapped integer. (#[38])
 - All bit length-type parameters take `u32` instead of `usize`. (#[38])
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "crypto-primes"
-version = "0.5.0"
+version = "0.6.0-pre.0"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = "Random prime number generation and primality checking library"
 repository = "https://github.com/entropyxyz/crypto-primes"
 readme = "README.md"
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.73"
 
 [dependencies]
-crypto-bigint = { version = "0.5.4", default-features = false, features = ["rand_core"] }
+crypto-bigint = { version = "0.6.0-pre.5", default-features = false, features = ["rand_core"] }
 rand_core = { version = "0.6.4", default-features = false }
 openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
 rug = { version = "1.18", default-features = false, features = ["integer"], optional = true }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -171,12 +171,13 @@ fn bench_lucas(c: &mut Criterion) {
     // - V_{d * 2^t} checked for t == 0..s-1, but no V = 0 found
     // - s = 5, so the previous step has multiple checks
     // - Q != 1 (since we're using Selfridge base)
-    let slow_path = U1024::from_be_hex(concat![
+    let slow_path = Odd::new(U1024::from_be_hex(concat![
         "D1CB9F1B6F3414A4B40A7E51C53C6AE4689DFCDC49FF875E7066A229D704EA8E",
         "6B674231D8C5974001673C3CE7FF9D377C8564E5182165A23434BC7B7E6C0419",
         "FD25C9921B0E9C90AF2570DB0772E1A9C82ACABBC8FC0F0864CE8A12124FA29B",
         "7F870924041DFA13EE5F5541C1BF96CA679EFAE2C96F5F4E9DF6007185198F5F"
-    ]);
+    ]))
+    .unwrap();
 
     group.bench_function("(U1024) Selfridge base, strong check, slow path", |b| {
         b.iter(|| {

--- a/src/hazmat/gcd.rs
+++ b/src/hazmat/gcd.rs
@@ -18,14 +18,17 @@ pub(crate) fn gcd<const L: usize>(n: &Uint<L>, m: u32) -> u32 {
     // Normalize input: the resulting (a, b) are both small, a >= b, and b != 0.
     let (mut a, mut b): (u32, u32) = if n.bits() > u32::BITS {
         // `m` is non-zero, so we can unwrap.
-        let (_quo, n) = n.div_rem_limb(NonZero::new(Limb::from(m)).unwrap());
+        let (_quo, n) =
+            n.div_rem_limb(NonZero::new(Limb::from(m)).expect("divisor ensured to be non-zero"));
         // `n` is a remainder of a division by `u32`, so it can be safely cast to `u32`.
-        let b: u32 = n.0.try_into().unwrap();
+        let b: u32 = n.0.try_into().expect("ensured to fit into `u32`");
         (m, b)
     } else {
         // In this branch `n` is 32 bits or shorter,
         // so we can safely take the first limb and cast it to u32.
-        let n: u32 = n.as_words()[0].try_into().unwrap();
+        let n: u32 = n.as_words()[0]
+            .try_into()
+            .expect("ensured to fit into `u32`");
         if n > m {
             (n, m)
         } else {

--- a/src/hazmat/gcd.rs
+++ b/src/hazmat/gcd.rs
@@ -16,7 +16,7 @@ pub(crate) fn gcd<const L: usize>(n: &Uint<L>, m: u32) -> u32 {
     }
 
     // Normalize input: the resulting (a, b) are both small, a >= b, and b != 0.
-    let (mut a, mut b): (u32, u32) = if n.bits() > (u32::BITS as usize) {
+    let (mut a, mut b): (u32, u32) = if n.bits() > u32::BITS {
         // `m` is non-zero, so we can unwrap.
         let (_quo, n) = n.div_rem_limb(NonZero::new(Limb::from(m)).unwrap());
         // `n` is a remainder of a division by `u32`, so it can be safely cast to `u32`.
@@ -47,7 +47,7 @@ pub(crate) fn gcd<const L: usize>(n: &Uint<L>, m: u32) -> u32 {
 
 #[cfg(test)]
 mod tests {
-    use crypto_bigint::{Encoding, U128};
+    use crypto_bigint::U128;
     use num_bigint::BigUint;
     use num_integer::Integer;
     use proptest::prelude::*;

--- a/src/hazmat/gcd.rs
+++ b/src/hazmat/gcd.rs
@@ -3,7 +3,7 @@ use crypto_bigint::{Limb, NonZero, Uint, Word};
 /// Calculates the greatest common divisor of `n` and `m`.
 /// By definition, `gcd(0, m) == m`.
 /// `n` must be non-zero.
-pub(crate) fn gcd<const L: usize>(n: &Uint<L>, m: Word) -> Word {
+pub(crate) fn gcd_vartime<const L: usize>(n: &Uint<L>, m: Word) -> Word {
     // This is an internal function, and it will never be called with `m = 0`.
     // Allowing `m = 0` would require us to have the return type of `Uint<L>`
     // (since `gcd(n, 0) = n`).
@@ -51,14 +51,17 @@ mod tests {
     use num_integer::Integer;
     use proptest::prelude::*;
 
-    use super::gcd;
+    use super::gcd_vartime;
 
     #[test]
     fn corner_cases() {
-        assert_eq!(gcd(&U128::from(0u64), 5), 5);
-        assert_eq!(gcd(&U128::from(1u64), 11 * 13 * 19), 1);
-        assert_eq!(gcd(&U128::from(7u64 * 11 * 13), 1), 1);
-        assert_eq!(gcd(&U128::from(7u64 * 11 * 13), 11 * 13 * 19), 11 * 13);
+        assert_eq!(gcd_vartime(&U128::from(0u64), 5), 5);
+        assert_eq!(gcd_vartime(&U128::from(1u64), 11 * 13 * 19), 1);
+        assert_eq!(gcd_vartime(&U128::from(7u64 * 11 * 13), 1), 1);
+        assert_eq!(
+            gcd_vartime(&U128::from(7u64 * 11 * 13), 11 * 13 * 19),
+            11 * 13
+        );
     }
 
     prop_compose! {
@@ -78,7 +81,7 @@ mod tests {
             let n_bi = BigUint::from_bytes_be(n.to_be_bytes().as_ref());
             let gcd_ref: Word = n_bi.gcd(&m_bi).try_into().unwrap();
 
-            let gcd_test = gcd(&n, m);
+            let gcd_test = gcd_vartime(&n, m);
             assert_eq!(gcd_test, gcd_ref);
         }
     }

--- a/src/hazmat/gcd.rs
+++ b/src/hazmat/gcd.rs
@@ -18,9 +18,8 @@ pub(crate) fn gcd_vartime<const L: usize>(n: &Uint<L>, m: Word) -> Word {
     // Normalize input: the resulting (a, b) are both small, a >= b, and b != 0.
     let (mut a, mut b): (Word, Word) = if n.bits() > Word::BITS {
         // `m` is non-zero, so we can unwrap.
-        let (_quo, n) =
-            n.div_rem_limb(NonZero::new(Limb::from(m)).expect("divisor ensured to be non-zero"));
-        (m, n.0)
+        let r = n.rem_limb(NonZero::new(Limb::from(m)).expect("divisor ensured to be non-zero"));
+        (m, r.0)
     } else {
         // In this branch `n` is `Word::BITS` bits or shorter,
         // so we can safely take the first limb.

--- a/src/hazmat/gcd.rs
+++ b/src/hazmat/gcd.rs
@@ -18,7 +18,7 @@ pub(crate) fn gcd_vartime<const L: usize>(n: &Uint<L>, m: Word) -> Word {
     // Normalize input: the resulting (a, b) are both small, a >= b, and b != 0.
     let (mut a, mut b): (Word, Word) = if n.bits() > Word::BITS {
         // `m` is non-zero, so we can unwrap.
-        let r = n.rem_limb(NonZero::new(Limb::from(m)).expect("divisor ensured to be non-zero"));
+        let r = n.rem_limb(NonZero::new(Limb::from(m)).expect("divisor should be non-zero here"));
         (m, r.0)
     } else {
         // In this branch `n` is `Word::BITS` bits or shorter,

--- a/src/hazmat/jacobi.rs
+++ b/src/hazmat/jacobi.rs
@@ -110,7 +110,8 @@ pub(crate) fn jacobi_symbol_vartime<const L: usize>(
         let (result, a_long, p) = swap(result, a, p_long.get());
         // Can unwrap here, since `p` is swapped with `a`,
         // and `a` would be odd after `reduce_numerator()`.
-        let a = a_long.rem_limb(NonZero::new(Limb::from(p)).expect("ensured to be non-zero"));
+        let a =
+            a_long.rem_limb(NonZero::new(Limb::from(p)).expect("divisor should be non-zero here"));
         (result, a.0, p)
     };
 

--- a/src/hazmat/jacobi.rs
+++ b/src/hazmat/jacobi.rs
@@ -110,8 +110,7 @@ pub(crate) fn jacobi_symbol_vartime<const L: usize>(
         let (result, a_long, p) = swap(result, a, p_long.get());
         // Can unwrap here, since `p` is swapped with `a`,
         // and `a` would be odd after `reduce_numerator()`.
-        let (_, a) =
-            a_long.div_rem_limb(NonZero::new(Limb::from(p)).expect("ensured to be non-zero"));
+        let a = a_long.rem_limb(NonZero::new(Limb::from(p)).expect("ensured to be non-zero"));
         (result, a.0, p)
     };
 

--- a/src/hazmat/jacobi.rs
+++ b/src/hazmat/jacobi.rs
@@ -151,7 +151,7 @@ mod tests {
 
     use alloc::format;
 
-    use crypto_bigint::{Encoding, U128};
+    use crypto_bigint::U128;
     use num_bigint::{BigInt, Sign};
     use num_modular::ModularSymbols;
     use proptest::prelude::*;

--- a/src/hazmat/jacobi.rs
+++ b/src/hazmat/jacobi.rs
@@ -113,7 +113,8 @@ pub(crate) fn jacobi_symbol<const L: usize>(a: i32, p_long: &Uint<L>) -> JacobiS
         let (result, a_long, p) = swap(result, a, *p_long);
         // Can unwrap here, since `p` is swapped with `a`,
         // and `a` would be odd after `reduce_numerator()`.
-        let (_, a) = a_long.div_rem_limb(NonZero::new(Limb::from(p)).unwrap());
+        let (_, a) =
+            a_long.div_rem_limb(NonZero::new(Limb::from(p)).expect("ensured to be non-zero"));
         (result, a.0, p)
     };
 

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -187,9 +187,12 @@ fn decompose<const L: usize>(n: &Odd<Uint<L>>) -> (u32, Odd<Uint<L>>) {
 
     let s = n.trailing_ones();
     let d = if s < n.bits_precision() {
-        // This won't overflow since the original `n` was odd, so we right-shifted at least once.
+        // The shift won't overflow because of the check above.
+        // The addition won't overflow since the original `n` was odd,
+        // so we right-shifted at least once.
         n.as_ref()
-            .wrapping_shr(s)
+            .overflowing_shr(s)
+            .expect("shift within range")
             .checked_add(&Uint::ONE)
             .expect("Integer overflow")
     } else {

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -1,7 +1,7 @@
 //! Lucas primality test.
 use crypto_bigint::{
     modular::{MontyForm, MontyParams},
-    CheckedAdd, Integer, Limb, Odd, Uint, Word,
+    CheckedAdd, Integer, Odd, Uint, Word,
 };
 
 use super::{
@@ -50,9 +50,11 @@ pub struct SelfridgeBase;
 impl LucasBase for SelfridgeBase {
     fn generate<const L: usize>(&self, n: &Odd<Uint<L>>) -> Result<(u32, i32), Primality> {
         let mut d = 5_i32;
-        let n_is_small = n.bits_vartime() < (Limb::BITS - 1);
+        let n_is_small = n.bits_vartime() < (u32::BITS - 1);
         // Can unwrap here since it won't overflow after `&`
-        let small_n: u32 = (n.as_words()[0] & Word::from(u32::MAX)).try_into().unwrap();
+        let small_n: u32 = (n.as_words()[0] & Word::from(u32::MAX))
+            .try_into()
+            .expect("ensured to fit into `u32`");
         let mut attempts = 0;
         loop {
             if attempts >= MAX_ATTEMPTS {
@@ -144,7 +146,7 @@ impl LucasBase for BruteForceBase {
             }
 
             // Can unwrap here since `p` is always small (see the condition above).
-            let j = jacobi_symbol((p * p - 4).try_into().unwrap(), n);
+            let j = jacobi_symbol((p * p - 4).try_into().expect("fits into `i32`"), n);
 
             if j == JacobiSymbol::MinusOne {
                 break;

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -192,14 +192,14 @@ fn decompose<const L: usize>(n: &Odd<Uint<L>>) -> (u32, Odd<Uint<L>>) {
         // so we right-shifted at least once.
         n.as_ref()
             .overflowing_shr(s)
-            .expect("shift within range")
+            .expect("shift should be within range by construction")
             .checked_add(&Uint::ONE)
-            .expect("Integer overflow")
+            .expect("addition should not overflow by construction")
     } else {
         Uint::ONE
     };
 
-    (s, Odd::new(d).expect("ensured to be odd"))
+    (s, Odd::new(d).expect("`d` should be odd by construction"))
 }
 
 /// The checks to perform in the Lucas test.

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -51,7 +51,7 @@ impl LucasBase for SelfridgeBase {
     fn generate<const L: usize>(&self, n: &Odd<Uint<L>>) -> Result<(Word, Word, bool), Primality> {
         let mut abs_d = 5;
         let mut d_is_negative = false;
-        let n_is_small = n.bits_vartime() < (Word::BITS - 1);
+        let n_is_small = n.bits_vartime() < Word::BITS; // if true, `n` fits into one `Word`
         let small_n = n.as_words()[0];
         let mut attempts = 0;
         loop {

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -812,6 +812,22 @@ mod tests {
         }
     }
 
+    #[test]
+    fn corner_cases() {
+        // Test 1 and 2 specifically
+
+        // By convention, 1 is composite. That's what `num-prime` returns.
+        let res = lucas_test(&U64::ONE, BruteForceBase, LucasCheck::AlmostExtraStrong);
+        assert_eq!(res, Primality::Composite);
+
+        let res = lucas_test(
+            &U64::from(2u32),
+            BruteForceBase,
+            LucasCheck::AlmostExtraStrong,
+        );
+        assert_eq!(res, Primality::Prime);
+    }
+
     #[cfg(feature = "tests-exhaustive")]
     #[test]
     fn exhaustive() {

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -5,8 +5,8 @@ use crypto_bigint::{
 };
 
 use super::{
-    gcd::gcd,
-    jacobi::{jacobi_symbol, JacobiSymbol},
+    gcd::gcd_vartime,
+    jacobi::{jacobi_symbol_vartime, JacobiSymbol},
     Primality,
 };
 
@@ -66,7 +66,7 @@ impl LucasBase for SelfridgeBase {
                 }
             }
 
-            let j = jacobi_symbol(abs_d, d_is_negative, n);
+            let j = jacobi_symbol_vartime(abs_d, d_is_negative, n);
 
             if j == JacobiSymbol::MinusOne {
                 break;
@@ -153,7 +153,7 @@ impl LucasBase for BruteForceBase {
             }
 
             // Can unwrap here since `p` is always small (see the condition above).
-            let j = jacobi_symbol(p * p - 4, false, n);
+            let j = jacobi_symbol_vartime(p * p - 4, false, n);
 
             if j == JacobiSymbol::MinusOne {
                 break;
@@ -335,7 +335,7 @@ pub fn lucas_test<const L: usize>(
     // But in order to avoid an implicit assumption that a sieve has been run,
     // we check that gcd(n, Q) = 1 anyway - again, since `Q` is small,
     // it does not noticeably affect the performance.
-    if abs_q != 1 && gcd(candidate, abs_q) != 1 && candidate > &Uint::<L>::from(abs_q) {
+    if abs_q != 1 && gcd_vartime(candidate, abs_q) != 1 && candidate > &Uint::<L>::from(abs_q) {
         return Primality::Composite;
     }
 

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -104,7 +104,8 @@ impl<const L: usize> MillerRabin<L> {
         }
 
         let range = self.candidate.wrapping_sub(&Uint::<L>::from(4u32));
-        let range_nonzero = NonZero::new(range).unwrap();
+        // Can unwrap here since `candidate` is odd, and `candidate >= 4` (as checked above)
+        let range_nonzero = NonZero::new(range).expect("ensured to be non-zero");
         // This should not overflow as long as `random_mod()` behaves according to the contract
         // (that is, returns a number within the given range).
         let random = Option::from(

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -108,10 +108,9 @@ impl<const L: usize> MillerRabin<L> {
         let range_nonzero = NonZero::new(range).expect("ensured to be non-zero");
         // This should not overflow as long as `random_mod()` behaves according to the contract
         // (that is, returns a number within the given range).
-        let random = Option::from(
-            Uint::<L>::random_mod(rng, &range_nonzero).checked_add(&Uint::<L>::from(3u32)),
-        )
-        .expect("Integer overflow");
+        let random = Uint::<L>::random_mod(rng, &range_nonzero)
+            .checked_add(&Uint::<L>::from(3u32))
+            .expect("Integer overflow");
         self.test(&random)
     }
 }

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -3,8 +3,8 @@
 use rand_core::CryptoRngCore;
 
 use crypto_bigint::{
-    modular::runtime_mod::{DynResidue, DynResidueParams},
-    CheckedAdd, Integer, NonZero, RandomMod, Uint,
+    modular::{MontyForm, MontyParams},
+    CheckedAdd, NonZero, Odd, RandomMod, Uint,
 };
 
 use super::Primality;
@@ -20,11 +20,11 @@ use super::Primality;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct MillerRabin<const L: usize> {
     candidate: Uint<L>,
-    bit_length: usize,
-    montgomery_params: DynResidueParams<L>,
-    one: DynResidue<L>,
-    minus_one: DynResidue<L>,
-    s: usize,
+    bit_length: u32,
+    montgomery_params: MontyParams<L>,
+    one: MontyForm<L>,
+    minus_one: MontyForm<L>,
+    s: u32,
     d: Uint<L>,
 }
 
@@ -32,19 +32,20 @@ impl<const L: usize> MillerRabin<L> {
     /// Initializes a Miller-Rabin test for `candidate`.
     ///
     /// Panics if `candidate` is even.
-    pub fn new(candidate: &Uint<L>) -> Self {
-        if candidate.is_even().into() {
-            panic!("`candidate` must be odd.");
-        }
-
-        let params = DynResidueParams::<L>::new(candidate);
-        let one = DynResidue::<L>::one(params);
+    pub fn new(candidate: Odd<Uint<L>>) -> Self {
+        let params = MontyParams::<L>::new(candidate);
+        let one = MontyForm::<L>::one(params);
         let minus_one = -one;
 
         // Find `s` and odd `d` such that `candidate - 1 == 2^s * d`.
-        let candidate_minus_one = candidate.wrapping_sub(&Uint::<L>::ONE);
-        let s = candidate_minus_one.trailing_zeros();
-        let d = candidate_minus_one >> s;
+        let (s, d) = if candidate.as_ref() == &Uint::ONE {
+            (0, Uint::ONE)
+        } else {
+            let candidate_minus_one = candidate.wrapping_sub(&Uint::ONE);
+            let s = candidate_minus_one.trailing_zeros();
+            let d = candidate_minus_one.shr(s);
+            (s, d)
+        };
 
         Self {
             candidate: *candidate,
@@ -62,7 +63,7 @@ impl<const L: usize> MillerRabin<L> {
         // TODO: it may be faster to first check that gcd(base, candidate) == 1,
         // otherwise we can return `Composite` right away.
 
-        let base = DynResidue::<L>::new(base, self.montgomery_params);
+        let base = MontyForm::<L>::new(base, self.montgomery_params);
 
         // Implementation detail: bounded exp gets faster every time we decrease the bound
         // by the window length it uses, which is currently 4 bits.
@@ -119,7 +120,7 @@ mod tests {
 
     use alloc::format;
 
-    use crypto_bigint::{Uint, U1024, U128, U1536, U64};
+    use crypto_bigint::{Odd, Uint, U1024, U128, U1536, U64};
     use rand_chacha::ChaCha8Rng;
     use rand_core::{CryptoRngCore, OsRng, SeedableRng};
 
@@ -131,15 +132,9 @@ mod tests {
 
     #[test]
     fn miller_rabin_derived_traits() {
-        let mr = MillerRabin::new(&U64::ONE);
+        let mr = MillerRabin::new(Odd::new(U64::ONE).unwrap());
         assert!(format!("{mr:?}").starts_with("MillerRabin"));
         assert_eq!(mr.clone(), mr);
-    }
-
-    #[test]
-    #[should_panic(expected = "`candidate` must be odd.")]
-    fn parity_check() {
-        let _mr = MillerRabin::new(&U64::from(10u32));
     }
 
     #[test]
@@ -147,7 +142,7 @@ mod tests {
         expected = "No suitable random base possible when `candidate == 3`; use the base 2 test."
     )]
     fn random_base_range_check() {
-        let mr = MillerRabin::new(&U64::from(3u32));
+        let mr = MillerRabin::new(Odd::new(U64::from(3u32)).unwrap());
         mr.test_random_base(&mut OsRng);
     }
 
@@ -179,7 +174,7 @@ mod tests {
             // with about 1/4 probability. So we're expecting less than
             // 35 out of 100 false positives, seems to work.
 
-            let mr = MillerRabin::new(&U64::from(*num));
+            let mr = MillerRabin::new(Odd::new(U64::from(*num)).unwrap());
             assert_eq!(
                 mr.test_base_two().is_probably_prime(),
                 actual_expected_result
@@ -195,9 +190,9 @@ mod tests {
     #[test]
     fn trivial() {
         let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
-        let start: U1024 = random_odd_uint(&mut rng, 1024);
+        let start: Odd<U1024> = random_odd_uint(&mut rng, 1024);
         for num in Sieve::new(&start, 1024, false).take(10) {
-            let mr = MillerRabin::new(&num);
+            let mr = MillerRabin::new(Odd::new(num).unwrap());
 
             // Trivial tests, must always be true.
             assert!(mr.test(&1u32.into()).is_probably_prime());
@@ -212,7 +207,7 @@ mod tests {
         // Mersenne prime 2^127-1
         let num = U128::from_be_hex("7fffffffffffffffffffffffffffffff");
 
-        let mr = MillerRabin::new(&num);
+        let mr = MillerRabin::new(Odd::new(num).unwrap());
         assert!(mr.test_base_two().is_probably_prime());
         for _ in 0..10 {
             assert!(mr.test_random_base(&mut rng).is_probably_prime());
@@ -224,7 +219,7 @@ mod tests {
         let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
 
         for num in pseudoprimes::STRONG_FIBONACCI.iter() {
-            let mr = MillerRabin::new(num);
+            let mr = MillerRabin::new(Odd::new(*num).unwrap());
             assert!(!mr.test_base_two().is_probably_prime());
             for _ in 0..1000 {
                 assert!(!mr.test_random_base(&mut rng).is_probably_prime());
@@ -252,7 +247,7 @@ mod tests {
 
     #[test]
     fn large_carmichael_number() {
-        let mr = MillerRabin::new(&pseudoprimes::LARGE_CARMICHAEL_NUMBER);
+        let mr = MillerRabin::new(Odd::new(pseudoprimes::LARGE_CARMICHAEL_NUMBER).unwrap());
 
         // It is known to pass MR tests for all prime bases <307
         assert!(mr.test_base_two().is_probably_prime());
@@ -265,7 +260,7 @@ mod tests {
     fn test_large_primes<const L: usize>(nums: &[Uint<L>]) {
         let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
         for num in nums {
-            let mr = MillerRabin::new(num);
+            let mr = MillerRabin::new(Odd::new(*num).unwrap());
             assert!(mr.test_base_two().is_probably_prime());
             for _ in 0..10 {
                 assert!(mr.test_random_base(&mut rng).is_probably_prime());
@@ -292,7 +287,7 @@ mod tests {
 
             let spsp = is_spsp(num);
 
-            let mr = MillerRabin::new(&U64::from(num));
+            let mr = MillerRabin::new(Odd::new(U64::from(num)).unwrap());
             let res = mr.test_base_two().is_probably_prime();
             let expected = spsp || res_ref;
             assert_eq!(

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -42,8 +42,8 @@ impl<const L: usize> MillerRabin<L> {
             (0, Uint::ONE)
         } else {
             let candidate_minus_one = candidate.wrapping_sub(&Uint::ONE);
-            let s = candidate_minus_one.trailing_zeros();
-            let d = candidate_minus_one.shr(s);
+            let s = candidate_minus_one.trailing_zeros_vartime();
+            let d = candidate_minus_one.wrapping_shr_vartime(s);
             (s, d)
         };
 

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -46,7 +46,7 @@ impl<const L: usize> MillerRabin<L> {
             // Will not overflow because `candidate` is odd and greater than 1.
             let d = candidate_minus_one
                 .overflowing_shr_vartime(s)
-                .expect("shift within range");
+                .expect("shift should be within range by construction");
             (s, d)
         };
 
@@ -108,12 +108,13 @@ impl<const L: usize> MillerRabin<L> {
 
         let range = self.candidate.wrapping_sub(&Uint::<L>::from(4u32));
         // Can unwrap here since `candidate` is odd, and `candidate >= 4` (as checked above)
-        let range_nonzero = NonZero::new(range).expect("ensured to be non-zero");
+        let range_nonzero =
+            NonZero::new(range).expect("the range should be non-zero by construction");
         // This should not overflow as long as `random_mod()` behaves according to the contract
         // (that is, returns a number within the given range).
         let random = Uint::<L>::random_mod(rng, &range_nonzero)
             .checked_add(&Uint::<L>::from(3u32))
-            .expect("Integer overflow");
+            .expect("addition should not overflow by construction");
         self.test(&random)
     }
 }

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -43,7 +43,10 @@ impl<const L: usize> MillerRabin<L> {
         } else {
             let candidate_minus_one = candidate.wrapping_sub(&Uint::ONE);
             let s = candidate_minus_one.trailing_zeros_vartime();
-            let d = candidate_minus_one.wrapping_shr_vartime(s);
+            // Will not overflow because `candidate` is odd and greater than 1.
+            let d = candidate_minus_one
+                .overflowing_shr_vartime(s)
+                .expect("shift within range");
             (s, d)
         };
 

--- a/src/hazmat/precomputed.rs
+++ b/src/hazmat/precomputed.rs
@@ -151,7 +151,11 @@ const fn create_reciprocals() -> [Reciprocal; SMALL_PRIMES_SIZE] {
     let mut arr = [Reciprocal::default(); SMALL_PRIMES_SIZE];
     let mut i = 0;
     while i < SMALL_PRIMES_SIZE {
-        arr[i] = Reciprocal::ct_new(Limb(SMALL_PRIMES[i] as Word)).0;
+        arr[i] = Reciprocal::new(
+            Limb(SMALL_PRIMES[i] as Word)
+                .to_nz()
+                .expect("ensured to be non-zero"),
+        );
         i += 1;
     }
     arr

--- a/src/hazmat/precomputed.rs
+++ b/src/hazmat/precomputed.rs
@@ -152,7 +152,7 @@ const fn create_reciprocals() -> [Reciprocal; SMALL_PRIMES.len()] {
         arr[i] = Reciprocal::new(
             Limb(SMALL_PRIMES[i] as Word)
                 .to_nz()
-                .expect("ensured to be non-zero"),
+                .expect("divisor should be non-zero"),
         );
         i += 1;
     }

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -37,7 +37,7 @@ pub fn random_odd_uint<const L: usize>(
     random |= Uint::<L>::ONE;
 
     // Make sure it's the correct bit size
-    random |= Uint::<L>::ONE << (bit_length - 1);
+    random |= Uint::<L>::ONE.wrapping_shl_vartime(bit_length - 1);
 
     Odd::new(random).expect("ensured to be odd")
 }
@@ -96,7 +96,7 @@ impl<const L: usize> Sieve<L> {
         // If we are targeting safe primes, iterate over the corresponding
         // possible Germain primes (`n/2`), reducing the task to that with `safe_primes = false`.
         let (max_bit_length, base) = if safe_primes {
-            (max_bit_length - 1, start >> 1)
+            (max_bit_length - 1, start.wrapping_shr_vartime(1))
         } else {
             (max_bit_length, *start)
         };
@@ -225,10 +225,10 @@ impl<const L: usize> Sieve<L> {
             // The overflow should never happen here since `incr`
             // is never greater than `incr_limit`, and the latter is chosen such that
             // it does not overflow when added to `base` (see `update_residues()`).
-            let mut num =
+            let mut num: Uint<L> =
                 Option::from(self.base.checked_add(&self.incr.into())).expect("Integer overflow");
             if self.safe_primes {
-                num = (num << 1) | Uint::<L>::ONE;
+                num = num.wrapping_shl_vartime(1) | Uint::<L>::ONE;
             }
             Some(num)
         };

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -40,9 +40,9 @@ pub fn random_odd_uint<const L: usize>(
     // Will not overflow since `bit_length` is ensured to be within the size of the integer.
     random |= Uint::<L>::ONE
         .overflowing_shl_vartime(bit_length - 1)
-        .expect("shift within range");
+        .expect("shift should be within range by construction");
 
-    Odd::new(random).expect("ensured to be odd")
+    Odd::new(random).expect("the number should be odd by construction")
 }
 
 // The type we use to calculate incremental residues.
@@ -164,7 +164,7 @@ impl<const L: usize> Sieve<L> {
         self.base = self
             .base
             .checked_add(&self.incr.into())
-            .expect("Integer overflow");
+            .expect("addition should not overflow by construction");
 
         self.incr = 0;
 
@@ -190,7 +190,7 @@ impl<const L: usize> Sieve<L> {
             // and `INCR_LIMIT` fits into `Residue`.
             let incr_limit_small: Residue = incr_limit.as_words()[0]
                 .try_into()
-                .expect("ensured to fit within `Residue`");
+                .expect("the increment limit should fit within `Residue`");
             incr_limit_small
         };
 
@@ -233,7 +233,7 @@ impl<const L: usize> Sieve<L> {
             let mut num: Uint<L> = self
                 .base
                 .checked_add(&self.incr.into())
-                .expect("Integer overflow");
+                .expect("addition should not overflow by construction");
             if self.safe_primes {
                 num = num.wrapping_shl_vartime(1) | Uint::<L>::ONE;
             }

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -167,7 +167,7 @@ impl<const L: usize> Sieve<L> {
 
         // Re-calculate residues.
         for (i, rec) in RECIPROCALS.iter().enumerate().take(self.residues.len()) {
-            let (_quo, rem) = self.base.div_rem_limb_with_reciprocal(rec);
+            let rem = self.base.rem_limb_with_reciprocal(rec);
             self.residues[i] = rem.0 as SmallPrime;
         }
 

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -183,7 +183,9 @@ impl<const L: usize> Sieve<L> {
             self.last_round = true;
             // Can unwrap here since we just checked above that `incr_limit <= INCR_LIMIT`,
             // and `INCR_LIMIT` fits into `Residue`.
-            let incr_limit_small: Residue = incr_limit.as_words()[0].try_into().unwrap();
+            let incr_limit_small: Residue = incr_limit.as_words()[0]
+                .try_into()
+                .expect("ensured to fit within `Residue`");
             incr_limit_small
         };
 

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -37,7 +37,10 @@ pub fn random_odd_uint<const L: usize>(
     random |= Uint::<L>::ONE;
 
     // Make sure it's the correct bit size
-    random |= Uint::<L>::ONE.wrapping_shl_vartime(bit_length - 1);
+    // Will not overflow since `bit_length` is ensured to be within the size of the integer.
+    random |= Uint::<L>::ONE
+        .overflowing_shl_vartime(bit_length - 1)
+        .expect("shift within range");
 
     Odd::new(random).expect("ensured to be odd")
 }

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -158,8 +158,10 @@ impl<const L: usize> Sieve<L> {
         // Should not overflow since `incr` is never greater than `incr_limit`,
         // and the latter is chosen such that it doesn't overflow when added to `base`
         // (see the rest of this method).
-        self.base =
-            Option::from(self.base.checked_add(&self.incr.into())).expect("Integer overflow");
+        self.base = self
+            .base
+            .checked_add(&self.incr.into())
+            .expect("Integer overflow");
 
         self.incr = 0;
 
@@ -225,8 +227,10 @@ impl<const L: usize> Sieve<L> {
             // The overflow should never happen here since `incr`
             // is never greater than `incr_limit`, and the latter is chosen such that
             // it does not overflow when added to `base` (see `update_residues()`).
-            let mut num: Uint<L> =
-                Option::from(self.base.checked_add(&self.incr.into())).expect("Integer overflow");
+            let mut num: Uint<L> = self
+                .base
+                .checked_add(&self.incr.into())
+                .expect("Integer overflow");
             if self.safe_primes {
                 num = num.wrapping_shl_vartime(1) | Uint::<L>::ONE;
             }

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -1,4 +1,4 @@
-use crypto_bigint::{Integer, Odd, Uint};
+use crypto_bigint::{Odd, Uint};
 use rand_core::CryptoRngCore;
 
 #[cfg(feature = "default-rng")]
@@ -125,11 +125,12 @@ pub fn is_prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, num: &Uin
     if num == &Uint::<L>::from(2u32) {
         return true;
     }
-    if num.is_even().into() {
-        return false;
-    }
 
-    let odd_num = Odd::new(*num).expect("ensured to be odd");
+    let odd_num = match Odd::new(*num).into() {
+        Some(x) => x,
+        None => return false,
+    };
+
     _is_prime_with_rng(rng, &odd_num)
 }
 
@@ -148,8 +149,8 @@ pub fn is_safe_prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, num:
     }
 
     // These are ensured to be odd by the check above.
-    let odd_num = Odd::new(*num).expect("ensured to be odd");
-    let odd_half_num = Odd::new(num.wrapping_shr_vartime(1)).expect("ensured to be odd");
+    let odd_num = Odd::new(*num).expect("`num` should be odd here");
+    let odd_half_num = Odd::new(num.wrapping_shr_vartime(1)).expect("`num/2` should be odd here");
 
     _is_prime_with_rng(rng, &odd_num) && _is_prime_with_rng(rng, &odd_half_num)
 }

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -1,4 +1,4 @@
-use crypto_bigint::{Integer, Uint};
+use crypto_bigint::{Integer, Odd, Uint};
 use rand_core::CryptoRngCore;
 
 #[cfg(feature = "default-rng")]
@@ -13,7 +13,7 @@ use crate::hazmat::{
 ///
 /// See [`is_prime_with_rng`] for details about the performed checks.
 #[cfg(feature = "default-rng")]
-pub fn generate_prime<const L: usize>(bit_length: Option<usize>) -> Uint<L> {
+pub fn generate_prime<const L: usize>(bit_length: Option<u32>) -> Uint<L> {
     generate_prime_with_rng(&mut OsRng, bit_length)
 }
 
@@ -23,7 +23,7 @@ pub fn generate_prime<const L: usize>(bit_length: Option<usize>) -> Uint<L> {
 ///
 /// See [`is_prime_with_rng`] for details about the performed checks.
 #[cfg(feature = "default-rng")]
-pub fn generate_safe_prime<const L: usize>(bit_length: Option<usize>) -> Uint<L> {
+pub fn generate_safe_prime<const L: usize>(bit_length: Option<u32>) -> Uint<L> {
     generate_safe_prime_with_rng(&mut OsRng, bit_length)
 }
 
@@ -53,14 +53,14 @@ pub fn is_safe_prime<const L: usize>(num: &Uint<L>) -> bool {
 /// See [`is_prime_with_rng`] for details about the performed checks.
 pub fn generate_prime_with_rng<const L: usize>(
     rng: &mut impl CryptoRngCore,
-    bit_length: Option<usize>,
+    bit_length: Option<u32>,
 ) -> Uint<L> {
     let bit_length = bit_length.unwrap_or(Uint::<L>::BITS);
     if bit_length < 2 {
         panic!("`bit_length` must be 2 or greater.");
     }
     loop {
-        let start: Uint<L> = random_odd_uint(rng, bit_length);
+        let start = random_odd_uint::<L>(rng, bit_length);
         let sieve = Sieve::new(&start, bit_length, false);
         for num in sieve {
             if is_prime_with_rng(rng, &num) {
@@ -79,14 +79,14 @@ pub fn generate_prime_with_rng<const L: usize>(
 /// See [`is_prime_with_rng`] for details about the performed checks.
 pub fn generate_safe_prime_with_rng<const L: usize>(
     rng: &mut impl CryptoRngCore,
-    bit_length: Option<usize>,
+    bit_length: Option<u32>,
 ) -> Uint<L> {
     let bit_length = bit_length.unwrap_or(Uint::<L>::BITS);
     if bit_length < 3 {
         panic!("`bit_length` must be 3 or greater.");
     }
     loop {
-        let start: Uint<L> = random_odd_uint(rng, bit_length);
+        let start = random_odd_uint::<L>(rng, bit_length);
         let sieve = Sieve::new(&start, bit_length, true);
         for num in sieve {
             if is_safe_prime_with_rng(rng, &num) {
@@ -152,7 +152,7 @@ pub fn is_safe_prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, num:
 /// Checks for primality assuming that `num` is odd.
 fn _is_prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, num: &Uint<L>) -> bool {
     debug_assert!(bool::from(num.is_odd()));
-    let mr = MillerRabin::new(num);
+    let mr = MillerRabin::new(Odd::new(*num).unwrap());
 
     if !mr.test_base_two().is_probably_prime() {
         return false;
@@ -232,7 +232,11 @@ mod tests {
                 assert!(is_safe_prime(&next));
             }
 
-            next = (next << 1).checked_add(&Uint::<L>::ONE).unwrap();
+            next = next
+                .overflowing_shl_vartime(1)
+                .unwrap()
+                .checked_add(&Uint::<L>::ONE)
+                .unwrap();
         }
 
         // The chain ended.
@@ -321,7 +325,7 @@ mod tests {
 
     #[test]
     fn corner_cases_generate_prime() {
-        for bits in 2usize..5 {
+        for bits in 2..5 {
             for _ in 0..100 {
                 let p: U64 = generate_prime(Some(bits));
                 let p_word = p.as_words()[0];
@@ -332,7 +336,7 @@ mod tests {
 
     #[test]
     fn corner_cases_generate_safe_prime() {
-        for bits in 3usize..5 {
+        for bits in 3..5 {
             for _ in 0..100 {
                 let p: U64 = generate_safe_prime(Some(bits));
                 let p_word = p.as_words()[0];
@@ -347,7 +351,7 @@ mod tests {
 mod tests_openssl {
     use alloc::format;
 
-    use crypto_bigint::U128;
+    use crypto_bigint::{Odd, U128};
     use openssl::bn::{BigNum, BigNumContext};
     use rand_core::OsRng;
 
@@ -390,7 +394,7 @@ mod tests_openssl {
 
         // Generate random numbers, check if our test agrees with OpenSSL
         for _ in 0..100 {
-            let p: U128 = random_odd_uint(&mut OsRng, 128);
+            let p: Odd<U128> = random_odd_uint(&mut OsRng, 128);
             let actual = is_prime(&p);
             let p_bn = to_openssl(&p);
             let expected = openssl_is_prime(&p_bn, &mut ctx);
@@ -405,7 +409,7 @@ mod tests_openssl {
 #[cfg(test)]
 #[cfg(feature = "tests-gmp")]
 mod tests_gmp {
-    use crypto_bigint::U128;
+    use crypto_bigint::{Odd, U128};
     use rand_core::OsRng;
     use rug::{
         integer::{IsPrime, Order},
@@ -438,7 +442,7 @@ mod tests_gmp {
 
         // Generate primes with GMP, check them
         for _ in 0..100 {
-            let start: U128 = random_odd_uint(&mut OsRng, 128);
+            let start: Odd<U128> = random_odd_uint(&mut OsRng, 128);
             let start_bn = to_gmp(&start);
             let p_bn = start_bn.next_prime();
             let p = from_gmp(&p_bn);
@@ -447,7 +451,7 @@ mod tests_gmp {
 
         // Generate random numbers, check if our test agrees with GMP
         for _ in 0..100 {
-            let p: U128 = random_odd_uint(&mut OsRng, 128);
+            let p: Odd<U128> = random_odd_uint(&mut OsRng, 128);
             let actual = is_prime(&p);
             let p_bn = to_gmp(&p);
             let expected = gmp_is_prime(&p_bn);

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -163,7 +163,7 @@ fn _is_prime_with_rng<const L: usize>(rng: &mut impl CryptoRngCore, num: &Odd<Ui
         return false;
     }
 
-    match lucas_test(num.as_ref(), AStarBase, LucasCheck::Strong) {
+    match lucas_test(num, AStarBase, LucasCheck::Strong) {
         Primality::Composite => return false,
         Primality::Prime => return true,
         _ => {}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,7 +15,7 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<usize>) -> Self;
+    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<u32>) -> Self;
 
     /// Returns a random safe prime (that is, such that `(n - 1) / 2` is also prime)
     /// of size `bit_length` using the provided RNG.
@@ -24,10 +24,7 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 3, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn generate_safe_prime_with_rng(
-        rng: &mut impl CryptoRngCore,
-        bit_length: Option<usize>,
-    ) -> Self;
+    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<u32>) -> Self;
 
     /// Checks probabilistically if the given number is prime using the provided RNG.
     ///
@@ -41,13 +38,10 @@ pub trait RandomPrimeWithRng {
 }
 
 impl<const L: usize> RandomPrimeWithRng for Uint<L> {
-    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<usize>) -> Self {
+    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<u32>) -> Self {
         generate_prime_with_rng(rng, bit_length)
     }
-    fn generate_safe_prime_with_rng(
-        rng: &mut impl CryptoRngCore,
-        bit_length: Option<usize>,
-    ) -> Self {
+    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<u32>) -> Self {
         generate_safe_prime_with_rng(rng, bit_length)
     }
     fn is_prime_with_rng(&self, rng: &mut impl CryptoRngCore) -> bool {


### PR DESCRIPTION
- Update for the changes in the API. In particular, all `bit_length` parameters are of type `u32` now.
- Use `Odd` where appropriate.
- Bump MSRV to 1.73 to match `crypto-bigint`.