### PR TITLE
Uint traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.73"
 
 [dependencies]
-crypto-bigint = { version = "0.6.0-pre.5", default-features = false, features = ["rand_core"] }
+crypto-bigint = { version = "0.6.0-pre.5", default-features = false, features = ["alloc", "rand_core"] }
 rand_core = { version = "0.6.4", default-features = false }
 openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
 rug = { version = "1.18", default-features = false, features = ["integer"], optional = true }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -22,8 +22,8 @@ fn make_rng() -> ChaCha8Rng {
     ChaCha8Rng::from_seed(*b"01234567890123456789012345678901")
 }
 
-fn make_sieve<const L: usize>(rng: &mut impl CryptoRngCore) -> Sieve<L> {
-    let start = random_odd_uint::<L>(rng, Uint::<L>::BITS);
+fn make_sieve<const L: usize>(rng: &mut impl CryptoRngCore) -> Sieve<Uint<L>> {
+    let start = random_odd_uint::<Uint<L>>(rng, Uint::<L>::BITS);
     Sieve::new(&start, Uint::<L>::BITS, false)
 }
 
@@ -36,13 +36,13 @@ fn bench_sieve(c: &mut Criterion) {
     let mut group = c.benchmark_group("Sieve");
 
     group.bench_function("(U128) random start", |b| {
-        b.iter(|| random_odd_uint::<{ nlimbs!(128) }>(&mut OsRng, 128))
+        b.iter(|| random_odd_uint::<Uint<{ nlimbs!(128) }>>(&mut OsRng, 128))
     });
 
     group.bench_function("(U128) creation", |b| {
         b.iter_batched(
-            || random_odd_uint::<{ nlimbs!(128) }>(&mut OsRng, 128),
-            |start| Sieve::new(&start, 128, false),
+            || random_odd_uint::<Uint<{ nlimbs!(128) }>>(&mut OsRng, 128),
+            |start| Sieve::new(start.as_ref(), 128, false),
             BatchSize::SmallInput,
         )
     });
@@ -57,13 +57,13 @@ fn bench_sieve(c: &mut Criterion) {
     });
 
     group.bench_function("(U1024) random start", |b| {
-        b.iter(|| random_odd_uint::<{ nlimbs!(1024) }>(&mut OsRng, 1024))
+        b.iter(|| random_odd_uint::<Uint<{ nlimbs!(1024) }>>(&mut OsRng, 1024))
     });
 
     group.bench_function("(U1024) creation", |b| {
         b.iter_batched(
-            || random_odd_uint::<{ nlimbs!(1024) }>(&mut OsRng, 1024),
-            |start| Sieve::new(&start, 1024, false),
+            || random_odd_uint::<Uint<{ nlimbs!(1024) }>>(&mut OsRng, 1024),
+            |start| Sieve::new(start.as_ref(), 1024, false),
             BatchSize::SmallInput,
         )
     });
@@ -84,7 +84,7 @@ fn bench_miller_rabin(c: &mut Criterion) {
 
     group.bench_function("(U128) creation", |b| {
         b.iter_batched(
-            || random_odd_uint::<{ nlimbs!(128) }>(&mut OsRng, 128),
+            || random_odd_uint::<Uint<{ nlimbs!(128) }>>(&mut OsRng, 128),
             MillerRabin::new,
             BatchSize::SmallInput,
         )
@@ -100,7 +100,7 @@ fn bench_miller_rabin(c: &mut Criterion) {
 
     group.bench_function("(U1024) creation", |b| {
         b.iter_batched(
-            || random_odd_uint::<{ nlimbs!(1024) }>(&mut OsRng, 1024),
+            || random_odd_uint::<Uint<{ nlimbs!(1024) }>>(&mut OsRng, 1024),
             MillerRabin::new,
             BatchSize::SmallInput,
         )
@@ -193,39 +193,39 @@ fn bench_presets(c: &mut Criterion) {
 
     group.bench_function("(U128) Prime test", |b| {
         b.iter_batched(
-            || random_odd_uint::<{ nlimbs!(128) }>(&mut OsRng, 128),
-            |num| is_prime_with_rng(&mut OsRng, &num),
+            || random_odd_uint::<Uint<{ nlimbs!(128) }>>(&mut OsRng, 128),
+            |num| is_prime_with_rng(&mut OsRng, num.as_ref()),
             BatchSize::SmallInput,
         )
     });
 
     group.bench_function("(U128) Safe prime test", |b| {
         b.iter_batched(
-            || random_odd_uint::<{ nlimbs!(128) }>(&mut OsRng, 128),
-            |num| is_safe_prime_with_rng(&mut OsRng, &num),
+            || random_odd_uint::<Uint<{ nlimbs!(128) }>>(&mut OsRng, 128),
+            |num| is_safe_prime_with_rng(&mut OsRng, num.as_ref()),
             BatchSize::SmallInput,
         )
     });
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random prime", |b| {
-        b.iter(|| generate_prime_with_rng::<{ nlimbs!(128) }>(&mut rng, None))
+        b.iter(|| generate_prime_with_rng::<Uint<{ nlimbs!(128) }>>(&mut rng, 128))
     });
 
     let mut rng = make_rng();
     group.bench_function("(U1024) Random prime", |b| {
-        b.iter(|| generate_prime_with_rng::<{ nlimbs!(1024) }>(&mut rng, None))
+        b.iter(|| generate_prime_with_rng::<Uint<{ nlimbs!(1024) }>>(&mut rng, 1024))
     });
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random safe prime", |b| {
-        b.iter(|| generate_safe_prime_with_rng::<{ nlimbs!(128) }>(&mut rng, None))
+        b.iter(|| generate_safe_prime_with_rng::<Uint<{ nlimbs!(128) }>>(&mut rng, 128))
     });
 
     group.sample_size(20);
     let mut rng = make_rng();
     group.bench_function("(U1024) Random safe prime", |b| {
-        b.iter(|| generate_safe_prime_with_rng::<{ nlimbs!(1024) }>(&mut rng, None))
+        b.iter(|| generate_safe_prime_with_rng::<Uint<{ nlimbs!(1024) }>>(&mut rng, 1024))
     });
 
     group.finish();
@@ -235,19 +235,19 @@ fn bench_presets(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random safe prime", |b| {
-        b.iter(|| generate_safe_prime_with_rng::<{ nlimbs!(128) }>(&mut rng, None))
+        b.iter(|| generate_safe_prime_with_rng::<Uint<{ nlimbs!(128) }>>(&mut rng, 128))
     });
 
     // The performance should scale with the prime size, not with the Uint size.
     // So we should strive for this test's result to be as close as possible
     // to that of the previous one and as far away as possible from the next one.
     group.bench_function("(U256) Random 128 bit safe prime", |b| {
-        b.iter(|| generate_safe_prime_with_rng::<{ nlimbs!(256) }>(&mut rng, Some(128)))
+        b.iter(|| generate_safe_prime_with_rng::<Uint<{ nlimbs!(256) }>>(&mut rng, 128))
     });
 
     // The upper bound for the previous test.
     group.bench_function("(U256) Random 256 bit safe prime", |b| {
-        b.iter(|| generate_safe_prime_with_rng::<{ nlimbs!(256) }>(&mut rng, None))
+        b.iter(|| generate_safe_prime_with_rng::<Uint<{ nlimbs!(256) }>>(&mut rng, 256))
     });
 
     group.finish();
@@ -258,7 +258,7 @@ fn bench_gmp(c: &mut Criterion) {
     let mut group = c.benchmark_group("GMP");
 
     fn random<const L: usize>(rng: &mut impl CryptoRngCore) -> Integer {
-        let num = random_odd_uint::<L>(rng, Uint::<L>::BITS);
+        let num = random_odd_uint::<Uint<L>>(rng, Uint::<L>::BITS).get();
         Integer::from_digits(num.as_words(), Order::Lsf)
     }
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -23,7 +23,7 @@ fn make_rng() -> ChaCha8Rng {
 }
 
 fn make_sieve<const L: usize>(rng: &mut impl CryptoRngCore) -> Sieve<Uint<L>> {
-    let start = random_odd_uint::<Uint<L>>(rng, Uint::<L>::BITS);
+    let start = random_odd_uint::<Uint<L>>(rng, Uint::<L>::BITS, Uint::<L>::BITS);
     Sieve::new(&start, Uint::<L>::BITS, false)
 }
 
@@ -36,12 +36,12 @@ fn bench_sieve(c: &mut Criterion) {
     let mut group = c.benchmark_group("Sieve");
 
     group.bench_function("(U128) random start", |b| {
-        b.iter(|| random_odd_uint::<Uint<{ nlimbs!(128) }>>(&mut OsRng, 128))
+        b.iter(|| random_odd_uint::<Uint<{ nlimbs!(128) }>>(&mut OsRng, 128, 128))
     });
 
     group.bench_function("(U128) creation", |b| {
         b.iter_batched(
-            || random_odd_uint::<Uint<{ nlimbs!(128) }>>(&mut OsRng, 128),
+            || random_odd_uint::<Uint<{ nlimbs!(128) }>>(&mut OsRng, 128, 128),
             |start| Sieve::new(start.as_ref(), 128, false),
             BatchSize::SmallInput,
         )
@@ -57,12 +57,12 @@ fn bench_sieve(c: &mut Criterion) {
     });
 
     group.bench_function("(U1024) random start", |b| {
-        b.iter(|| random_odd_uint::<Uint<{ nlimbs!(1024) }>>(&mut OsRng, 1024))
+        b.iter(|| random_odd_uint::<Uint<{ nlimbs!(1024) }>>(&mut OsRng, 1024, 1024))
     });
 
     group.bench_function("(U1024) creation", |b| {
         b.iter_batched(
-            || random_odd_uint::<Uint<{ nlimbs!(1024) }>>(&mut OsRng, 1024),
+            || random_odd_uint::<Uint<{ nlimbs!(1024) }>>(&mut OsRng, 1024, 1024),
             |start| Sieve::new(start.as_ref(), 1024, false),
             BatchSize::SmallInput,
         )
@@ -84,7 +84,7 @@ fn bench_miller_rabin(c: &mut Criterion) {
 
     group.bench_function("(U128) creation", |b| {
         b.iter_batched(
-            || random_odd_uint::<Uint<{ nlimbs!(128) }>>(&mut OsRng, 128),
+            || random_odd_uint::<Uint<{ nlimbs!(128) }>>(&mut OsRng, 128, 128),
             MillerRabin::new,
             BatchSize::SmallInput,
         )
@@ -100,7 +100,7 @@ fn bench_miller_rabin(c: &mut Criterion) {
 
     group.bench_function("(U1024) creation", |b| {
         b.iter_batched(
-            || random_odd_uint::<Uint<{ nlimbs!(1024) }>>(&mut OsRng, 1024),
+            || random_odd_uint::<Uint<{ nlimbs!(1024) }>>(&mut OsRng, 1024, 1024),
             MillerRabin::new,
             BatchSize::SmallInput,
         )
@@ -193,7 +193,7 @@ fn bench_presets(c: &mut Criterion) {
 
     group.bench_function("(U128) Prime test", |b| {
         b.iter_batched(
-            || random_odd_uint::<Uint<{ nlimbs!(128) }>>(&mut OsRng, 128),
+            || random_odd_uint::<Uint<{ nlimbs!(128) }>>(&mut OsRng, 128, 128),
             |num| is_prime_with_rng(&mut OsRng, num.as_ref()),
             BatchSize::SmallInput,
         )
@@ -201,7 +201,7 @@ fn bench_presets(c: &mut Criterion) {
 
     group.bench_function("(U128) Safe prime test", |b| {
         b.iter_batched(
-            || random_odd_uint::<Uint<{ nlimbs!(128) }>>(&mut OsRng, 128),
+            || random_odd_uint::<Uint<{ nlimbs!(128) }>>(&mut OsRng, 128, 128),
             |num| is_safe_prime_with_rng(&mut OsRng, num.as_ref()),
             BatchSize::SmallInput,
         )
@@ -209,23 +209,23 @@ fn bench_presets(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random prime", |b| {
-        b.iter(|| generate_prime_with_rng::<Uint<{ nlimbs!(128) }>>(&mut rng, 128))
+        b.iter(|| generate_prime_with_rng::<Uint<{ nlimbs!(128) }>>(&mut rng, 128, 128))
     });
 
     let mut rng = make_rng();
     group.bench_function("(U1024) Random prime", |b| {
-        b.iter(|| generate_prime_with_rng::<Uint<{ nlimbs!(1024) }>>(&mut rng, 1024))
+        b.iter(|| generate_prime_with_rng::<Uint<{ nlimbs!(1024) }>>(&mut rng, 1024, 1024))
     });
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random safe prime", |b| {
-        b.iter(|| generate_safe_prime_with_rng::<Uint<{ nlimbs!(128) }>>(&mut rng, 128))
+        b.iter(|| generate_safe_prime_with_rng::<Uint<{ nlimbs!(128) }>>(&mut rng, 128, 128))
     });
 
     group.sample_size(20);
     let mut rng = make_rng();
     group.bench_function("(U1024) Random safe prime", |b| {
-        b.iter(|| generate_safe_prime_with_rng::<Uint<{ nlimbs!(1024) }>>(&mut rng, 1024))
+        b.iter(|| generate_safe_prime_with_rng::<Uint<{ nlimbs!(1024) }>>(&mut rng, 1024, 1024))
     });
 
     group.finish();
@@ -235,19 +235,19 @@ fn bench_presets(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random safe prime", |b| {
-        b.iter(|| generate_safe_prime_with_rng::<Uint<{ nlimbs!(128) }>>(&mut rng, 128))
+        b.iter(|| generate_safe_prime_with_rng::<Uint<{ nlimbs!(128) }>>(&mut rng, 128, 128))
     });
 
     // The performance should scale with the prime size, not with the Uint size.
     // So we should strive for this test's result to be as close as possible
     // to that of the previous one and as far away as possible from the next one.
     group.bench_function("(U256) Random 128 bit safe prime", |b| {
-        b.iter(|| generate_safe_prime_with_rng::<Uint<{ nlimbs!(256) }>>(&mut rng, 128))
+        b.iter(|| generate_safe_prime_with_rng::<Uint<{ nlimbs!(256) }>>(&mut rng, 128, 256))
     });
 
     // The upper bound for the previous test.
     group.bench_function("(U256) Random 256 bit safe prime", |b| {
-        b.iter(|| generate_safe_prime_with_rng::<Uint<{ nlimbs!(256) }>>(&mut rng, 256))
+        b.iter(|| generate_safe_prime_with_rng::<Uint<{ nlimbs!(256) }>>(&mut rng, 256, 256))
     });
 
     group.finish();
@@ -258,7 +258,7 @@ fn bench_gmp(c: &mut Criterion) {
     let mut group = c.benchmark_group("GMP");
 
     fn random<const L: usize>(rng: &mut impl CryptoRngCore) -> Integer {
-        let num = random_odd_uint::<Uint<L>>(rng, Uint::<L>::BITS).get();
+        let num = random_odd_uint::<Uint<L>>(rng, Uint::<L>::BITS, Uint::<L>::BITS).get();
         Integer::from_digits(num.as_words(), Order::Lsf)
     }
 

--- a/src/hazmat/gcd.rs
+++ b/src/hazmat/gcd.rs
@@ -1,9 +1,9 @@
-use crypto_bigint::{Limb, NonZero, Uint, Word};
+use crypto_bigint::{Integer, Limb, NonZero, Word};
 
 /// Calculates the greatest common divisor of `n` and `m`.
 /// By definition, `gcd(0, m) == m`.
 /// `n` must be non-zero.
-pub(crate) fn gcd_vartime<const L: usize>(n: &Uint<L>, m: Word) -> Word {
+pub(crate) fn gcd_vartime<T: Integer>(n: &T, m: Word) -> Word {
     // This is an internal function, and it will never be called with `m = 0`.
     // Allowing `m = 0` would require us to have the return type of `Uint<L>`
     // (since `gcd(n, 0) = n`).
@@ -11,7 +11,7 @@ pub(crate) fn gcd_vartime<const L: usize>(n: &Uint<L>, m: Word) -> Word {
 
     // This we can check since it doesn't affect the return type,
     // even though `n` will not be 0 either in the application.
-    if n == &Uint::<L>::ZERO {
+    if n.is_zero().into() {
         return m;
     }
 
@@ -23,7 +23,7 @@ pub(crate) fn gcd_vartime<const L: usize>(n: &Uint<L>, m: Word) -> Word {
     } else {
         // In this branch `n` is `Word::BITS` bits or shorter,
         // so we can safely take the first limb.
-        let n = n.as_words()[0];
+        let n = n.as_ref()[0].0;
         if n > m {
             (n, m)
         } else {

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -352,7 +352,10 @@ pub fn lucas_test<T: UintLike>(
     let q = if q_is_one {
         one.clone()
     } else {
-        let abs_q = <T as Integer>::Monty::new(T::from(abs_q), params.clone());
+        let abs_q = <T as Integer>::Monty::new(
+            T::from(abs_q).widen(candidate.bits_precision()),
+            params.clone(),
+        );
         if q_is_negative {
             -abs_q
         } else {
@@ -365,7 +368,7 @@ pub fn lucas_test<T: UintLike>(
     let p = if p_is_one {
         one.clone()
     } else {
-        <T as Integer>::Monty::new(T::from(p), params.clone())
+        <T as Integer>::Monty::new(T::from(p).widen(candidate.bits_precision()), params.clone())
     };
 
     // Compute d-th element of Lucas sequence (U_d(P, Q), V_d(P, Q)), where:
@@ -388,7 +391,8 @@ pub fn lucas_test<T: UintLike>(
     let mut qk = one.clone(); // keeps Q^k
 
     // D in Montgomery representation - note that it can be negative.
-    let abs_d = <T as Integer>::Monty::new(T::from(abs_d), params);
+    let abs_d =
+        <T as Integer>::Monty::new(T::from(abs_d).widen(candidate.bits_precision()), params);
     let d_m = if d_is_negative { -abs_d } else { abs_d };
 
     for i in (0..d.bits_vartime()).rev() {

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -192,7 +192,7 @@ mod tests {
     #[test]
     fn trivial() {
         let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
-        let start = random_odd_uint::<U1024>(&mut rng, 1024);
+        let start = random_odd_uint::<U1024>(&mut rng, 1024, U1024::BITS);
         for num in Sieve::new(start.as_ref(), 1024, false).take(10) {
             let mr = MillerRabin::new(Odd::new(num).unwrap());
 

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -33,10 +33,11 @@ impl<T: UintLike> MillerRabin<T> {
         let minus_one = -one.clone();
 
         // Find `s` and odd `d` such that `candidate - 1 == 2^s * d`.
-        let (s, d) = if candidate.as_ref() == &T::one() {
-            (0, T::one())
+        let (s, d) = if candidate.as_ref() == &T::one_with_precision(candidate.bits_precision()) {
+            (0, T::one_with_precision(candidate.bits_precision()))
         } else {
-            let candidate_minus_one = candidate.wrapping_sub(&T::one());
+            let candidate_minus_one =
+                candidate.wrapping_sub(&T::one_with_precision(candidate.bits_precision()));
             let s = candidate_minus_one.trailing_zeros_vartime();
             // Will not overflow because `candidate` is odd and greater than 1.
             let d = candidate_minus_one
@@ -86,7 +87,7 @@ impl<T: UintLike> MillerRabin<T> {
 
     /// Perform a Miller-Rabin check with base 2.
     pub fn test_base_two(&self) -> Primality {
-        self.test(&T::from(2u32))
+        self.test(&T::from(2u32).widen(self.candidate.bits_precision()))
     }
 
     /// Perform a Miller-Rabin check with a random base (in the range `[3, candidate-2]`)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ extern crate alloc;
 pub mod hazmat;
 mod presets;
 mod traits;
+mod uint_traits;
 
 pub use presets::{
     generate_prime_with_rng, generate_safe_prime_with_rng, is_prime_with_rng,
@@ -27,3 +28,5 @@ pub use traits::RandomPrimeWithRng;
 
 #[cfg(feature = "default-rng")]
 pub use presets::{generate_prime, generate_safe_prime, is_prime, is_safe_prime};
+
+pub use uint_traits::UintLike;

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -180,7 +180,7 @@ fn _is_prime_with_rng<T: UintLike>(rng: &mut impl CryptoRngCore, num: &Odd<T>) -
 
 #[cfg(test)]
 mod tests {
-    use crypto_bigint::{CheckedAdd, Uint, Word, U128, U64};
+    use crypto_bigint::{BoxedUint, CheckedAdd, Uint, Word, U128, U64};
     use num_prime::nt_funcs::is_prime64;
     use rand_core::OsRng;
 
@@ -268,9 +268,27 @@ mod tests {
     }
 
     #[test]
+    fn prime_generation_boxed() {
+        for bit_length in (28..=128).step_by(10) {
+            let p: BoxedUint = generate_prime(bit_length, 128);
+            assert!(p.bits_vartime() == bit_length);
+            assert!(is_prime(&p));
+        }
+    }
+
+    #[test]
     fn safe_prime_generation() {
         for bit_length in (28..=128).step_by(10) {
             let p: U128 = generate_safe_prime(bit_length, U128::BITS);
+            assert!(p.bits_vartime() == bit_length);
+            assert!(is_safe_prime(&p));
+        }
+    }
+
+    #[test]
+    fn safe_prime_generation_boxed() {
+        for bit_length in (28..=128).step_by(10) {
+            let p: BoxedUint = generate_safe_prime(bit_length, 128);
             assert!(p.bits_vartime() == bit_length);
             assert!(is_safe_prime(&p));
         }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,7 +15,11 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self;
+    fn generate_prime_with_rng(
+        rng: &mut impl CryptoRngCore,
+        bit_length: u32,
+        bits_precision: u32,
+    ) -> Self;
 
     /// Returns a random safe prime (that is, such that `(n - 1) / 2` is also prime)
     /// of size `bit_length` using the provided RNG.
@@ -24,7 +28,11 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 3, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self;
+    fn generate_safe_prime_with_rng(
+        rng: &mut impl CryptoRngCore,
+        bit_length: u32,
+        bits_precision: u32,
+    ) -> Self;
 
     /// Checks probabilistically if the given number is prime using the provided RNG.
     ///
@@ -38,11 +46,19 @@ pub trait RandomPrimeWithRng {
 }
 
 impl<const L: usize> RandomPrimeWithRng for Uint<L> {
-    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
-        generate_prime_with_rng(rng, bit_length)
+    fn generate_prime_with_rng(
+        rng: &mut impl CryptoRngCore,
+        bit_length: u32,
+        bits_precision: u32,
+    ) -> Self {
+        generate_prime_with_rng(rng, bit_length, bits_precision)
     }
-    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
-        generate_safe_prime_with_rng(rng, bit_length)
+    fn generate_safe_prime_with_rng(
+        rng: &mut impl CryptoRngCore,
+        bit_length: u32,
+        bits_precision: u32,
+    ) -> Self {
+        generate_safe_prime_with_rng(rng, bit_length, bits_precision)
     }
     fn is_prime_with_rng(&self, rng: &mut impl CryptoRngCore) -> bool {
         is_prime_with_rng(rng, self)
@@ -67,9 +83,10 @@ mod tests {
         assert!(!U64::from(13u32).is_safe_prime_with_rng(&mut OsRng));
         assert!(U64::from(11u32).is_safe_prime_with_rng(&mut OsRng));
 
-        assert!(U64::generate_prime_with_rng(&mut OsRng, 10).is_prime_with_rng(&mut OsRng));
         assert!(
-            U64::generate_safe_prime_with_rng(&mut OsRng, 10).is_safe_prime_with_rng(&mut OsRng)
+            U64::generate_prime_with_rng(&mut OsRng, 10, U64::BITS).is_prime_with_rng(&mut OsRng)
         );
+        assert!(U64::generate_safe_prime_with_rng(&mut OsRng, 10, U64::BITS)
+            .is_safe_prime_with_rng(&mut OsRng));
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,7 +15,7 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<u32>) -> Self;
+    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self;
 
     /// Returns a random safe prime (that is, such that `(n - 1) / 2` is also prime)
     /// of size `bit_length` using the provided RNG.
@@ -24,7 +24,7 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 3, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<u32>) -> Self;
+    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self;
 
     /// Checks probabilistically if the given number is prime using the provided RNG.
     ///
@@ -38,10 +38,10 @@ pub trait RandomPrimeWithRng {
 }
 
 impl<const L: usize> RandomPrimeWithRng for Uint<L> {
-    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<u32>) -> Self {
+    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
         generate_prime_with_rng(rng, bit_length)
     }
-    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: Option<u32>) -> Self {
+    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
         generate_safe_prime_with_rng(rng, bit_length)
     }
     fn is_prime_with_rng(&self, rng: &mut impl CryptoRngCore) -> bool {
@@ -67,8 +67,9 @@ mod tests {
         assert!(!U64::from(13u32).is_safe_prime_with_rng(&mut OsRng));
         assert!(U64::from(11u32).is_safe_prime_with_rng(&mut OsRng));
 
-        assert!(U64::generate_prime_with_rng(&mut OsRng, Some(10)).is_prime_with_rng(&mut OsRng));
-        assert!(U64::generate_safe_prime_with_rng(&mut OsRng, Some(10))
-            .is_safe_prime_with_rng(&mut OsRng));
+        assert!(U64::generate_prime_with_rng(&mut OsRng, 10).is_prime_with_rng(&mut OsRng));
+        assert!(
+            U64::generate_safe_prime_with_rng(&mut OsRng, 10).is_safe_prime_with_rng(&mut OsRng)
+        );
     }
 }

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -15,6 +15,9 @@ pub trait UintLike: Integer + RandomMod {
     fn wrapping_shl_vartime(&self, shift: u32) -> Self;
     fn wrapping_shr_vartime(&self, shift: u32) -> Self;
     fn random_bits(rng: &mut impl CryptoRngCore, bit_length: u32, bits_precision: u32) -> Self;
+    fn one_with_precision(bits_precision: u32) -> Self;
+    fn zero_with_precision(bits_precision: u32) -> Self;
+    fn widen(&self, bits_precision: u32) -> Self;
 }
 
 // Uint<L> impls
@@ -73,6 +76,18 @@ impl<const L: usize> UintLike for Uint<L> {
         let random = Self::random(rng);
         random >> (Self::BITS - bit_length)
     }
+
+    fn one_with_precision(_bits_precision: u32) -> Self {
+        Self::ONE
+    }
+
+    fn zero_with_precision(_bits_precision: u32) -> Self {
+        Self::ZERO
+    }
+
+    fn widen(&self, _bits_precision: u32) -> Self {
+        *self
+    }
 }
 
 impl UintLike for BoxedUint {
@@ -101,13 +116,13 @@ impl UintLike for BoxedUint {
     }
 
     fn overflowing_shl_vartime(&self, shift: u32) -> CtOption<Self> {
-        let (res, is_some) = Self::overflowing_shl(self, shift);
-        CtOption::new(res, is_some)
+        let (res, overflow) = Self::overflowing_shl(self, shift);
+        CtOption::new(res, !overflow)
     }
 
     fn overflowing_shr_vartime(&self, shift: u32) -> CtOption<Self> {
-        let (res, is_some) = Self::overflowing_shr(self, shift);
-        CtOption::new(res, is_some)
+        let (res, overflow) = Self::overflowing_shr(self, shift);
+        CtOption::new(res, !overflow)
     }
 
     fn wrapping_shl_vartime(&self, shift: u32) -> Self {
@@ -124,5 +139,17 @@ impl UintLike for BoxedUint {
         }
         let random = Self::random(rng, bits_precision);
         random >> (bits_precision - bit_length)
+    }
+
+    fn zero_with_precision(bits_precision: u32) -> Self {
+        Self::zero_with_precision(bits_precision)
+    }
+
+    fn one_with_precision(bits_precision: u32) -> Self {
+        Self::one_with_precision(bits_precision)
+    }
+
+    fn widen(&self, bits_precision: u32) -> Self {
+        self.widen(bits_precision)
     }
 }

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -78,9 +78,9 @@ impl<const L: usize> UintLike for Uint<L> {
 impl UintLike for BoxedUint {
     fn set_bit_vartime(&mut self, index: u32, value: bool) {
         if value {
-            *self |= Self::one() << index
+            *self |= Self::one_with_precision(self.bits_precision()) << index
         } else {
-            *self &= (Self::one() << index).not()
+            *self &= (Self::one_with_precision(self.bits_precision()) << index).not()
         }
     }
 

--- a/src/uint_traits.rs
+++ b/src/uint_traits.rs
@@ -1,0 +1,120 @@
+#![allow(missing_docs)]
+
+use crypto_bigint::{subtle::CtOption, BoxedUint, Integer, Random, RandomMod, Uint};
+use rand_core::CryptoRngCore;
+
+// would be nice to have: *Assign traits; arithmetic traits for &self (BitAnd and Shr in particular);
+pub trait UintLike: Integer + RandomMod {
+    fn bit_vartime(&self, index: u32) -> bool;
+    fn set_bit_vartime(&mut self, index: u32, value: bool);
+    fn trailing_zeros_vartime(&self) -> u32;
+    fn trailing_ones_vartime(&self) -> u32;
+    fn sqrt_vartime(&self) -> Self;
+    fn overflowing_shl_vartime(&self, shift: u32) -> CtOption<Self>;
+    fn overflowing_shr_vartime(&self, shift: u32) -> CtOption<Self>;
+    fn wrapping_shl_vartime(&self, shift: u32) -> Self;
+    fn wrapping_shr_vartime(&self, shift: u32) -> Self;
+    fn random_bits(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self;
+}
+
+// Uint<L> impls
+
+impl<const L: usize> UintLike for Uint<L> {
+    fn set_bit_vartime(&mut self, index: u32, value: bool) {
+        if value {
+            *self |= Uint::ONE << index
+        } else {
+            *self &= (Uint::ONE << index).not()
+        }
+    }
+
+    fn trailing_zeros_vartime(&self) -> u32 {
+        Self::trailing_zeros_vartime(self)
+    }
+
+    fn trailing_ones_vartime(&self) -> u32 {
+        Self::trailing_ones_vartime(self)
+    }
+
+    fn bit_vartime(&self, index: u32) -> bool {
+        Self::bit_vartime(self, index)
+    }
+
+    fn sqrt_vartime(&self) -> Self {
+        Self::sqrt_vartime(self)
+    }
+
+    fn overflowing_shl_vartime(&self, shift: u32) -> CtOption<Self> {
+        Self::overflowing_shl_vartime(self, shift).into()
+    }
+
+    fn overflowing_shr_vartime(&self, shift: u32) -> CtOption<Self> {
+        Self::overflowing_shr_vartime(self, shift).into()
+    }
+
+    fn wrapping_shl_vartime(&self, shift: u32) -> Self {
+        Self::wrapping_shl_vartime(self, shift)
+    }
+
+    fn wrapping_shr_vartime(&self, shift: u32) -> Self {
+        Self::wrapping_shr_vartime(self, shift)
+    }
+
+    fn random_bits(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
+        if bit_length > Self::BITS {
+            panic!("The requested bit length ({bit_length}) is larger than the chosen Uint size");
+        }
+        let random = Self::random(rng);
+        random >> (Self::BITS - bit_length)
+    }
+}
+
+impl UintLike for BoxedUint {
+    fn set_bit_vartime(&mut self, index: u32, value: bool) {
+        if value {
+            *self |= Self::one() << index
+        } else {
+            *self &= (Self::one() << index).not()
+        }
+    }
+
+    fn trailing_zeros_vartime(&self) -> u32 {
+        Self::trailing_zeros(self)
+    }
+
+    fn trailing_ones_vartime(&self) -> u32 {
+        Self::trailing_ones_vartime(self)
+    }
+
+    fn bit_vartime(&self, index: u32) -> bool {
+        Self::bit_vartime(self, index)
+    }
+
+    fn sqrt_vartime(&self) -> Self {
+        Self::sqrt_vartime(self)
+    }
+
+    fn overflowing_shl_vartime(&self, shift: u32) -> CtOption<Self> {
+        let (res, is_some) = Self::overflowing_shl(self, shift);
+        CtOption::new(res, is_some)
+    }
+
+    fn overflowing_shr_vartime(&self, shift: u32) -> CtOption<Self> {
+        let (res, is_some) = Self::overflowing_shr(self, shift);
+        CtOption::new(res, is_some)
+    }
+
+    fn wrapping_shl_vartime(&self, shift: u32) -> Self {
+        Self::wrapping_shl_vartime(self, shift)
+    }
+
+    fn wrapping_shr_vartime(&self, shift: u32) -> Self {
+        Self::wrapping_shr_vartime(self, shift)
+    }
+
+    fn random_bits(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
+        let random = Self::random(rng, bit_length);
+        let bits_precision = random.bits_precision();
+        random >> (bits_precision - bit_length)
+    }
+}


### PR DESCRIPTION
This PR builds upon #36 and adds the following items:

1. Two tests in `presets.rs`: `prime_generation_boxed` and `safe_prime_generation_boxed`, both of which pass
2. Some fixes to `overflowing_shl_vartime` and `overflowing_shr_vartime`, as well as `random_bits` for `BoxedUint`
3. Added `one_with_precision`, `zero_with_precision`, and `widen` to `UintLike` so that all `BoxedUint` sizes can be kept identical
4. Modified `miller_rabin.rs` and `lucas.rs` to maintain equal `BoxedUint` sizes across the entire module.

The most awkward part of these proposed changes is the need for `one_with_precision`, `zero_with_precision`, and `widen`, which makes sense in the context of `BoxedUint` but feels redundant when working with `Uint`. Again, I think some clear documentation will suffice, but maybe there are some better ways.

cc: @fjarri