### PR TITLE
`BoxedUint` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `random_odd_uint()` is renamed to `random_odd_integer()`, takes a `NonZeroU32` for `bit_length`. ([#38])
 - All bit length-type parameters take `u32` instead of `usize`. ([#36])
 - All the API is based on the `Integer` trait instead of `Uint` specifically. ([#38])
+- High-level generation/checking functions take an additional `bits_precision` argument. ([#40])
 
 
 [#36]: https://github.com/entropyxyz/crypto-primes/pull/36

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bumped `crypto-bigint` to 0.6.0-pre.6. ([#36])
+- Bumped `crypto-bigint` to 0.6.0-pre.7. ([#40])
 - Bumped MSRV to 1.73. ([#36])
 - `MillerRabin::new()` takes an `Odd`-wrapped integer by value. `random_odd_uint()` returns an `Odd`-wrapped integer. `LucasBase::generate()` takes an `Odd`-wrapped integer. `lucas_test` takes an `Odd`-wrapped integer. ([#36])
 - `random_odd_uint()` is renamed to `random_odd_integer()`, takes a `NonZeroU32` for `bit_length`. ([#38])
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#36]: https://github.com/entropyxyz/crypto-primes/pull/36
 [#38]: https://github.com/entropyxyz/crypto-primes/pull/38
+[#40]: https://github.com/entropyxyz/crypto-primes/pull/40
 
 
 ## [0.5.0] - 2023-08-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bumped `crypto-bigint` to 0.6.0-pre.6. ([#38])
-- Bumped MSRV to 1.73. (#[38])
-- `MillerRabin::new()` takes an `Odd`-wrapped integer. `random_odd_uint()` is renamed to `random_odd_integer()`, takes a `NonZeroU32` for `bit_length`, and returns an `Odd`-wrapped integer. `LucasBase::generate()` takes an `Odd`-wrapped integer. `lucas_test` takes an `Odd`-wrapped integer. (#[38])
-- All bit length-type parameters take `u32` instead of `usize`. (#[38])
-- All the API is based on the `Integer` trait instead of `Uint` specifically. (#[38])
+- Bumped `crypto-bigint` to 0.6.0-pre.6. ([#36])
+- Bumped MSRV to 1.73. ([#36])
+- `MillerRabin::new()` takes an `Odd`-wrapped integer by value. `random_odd_uint()` returns an `Odd`-wrapped integer. `LucasBase::generate()` takes an `Odd`-wrapped integer. `lucas_test` takes an `Odd`-wrapped integer. ([#36])
+- `random_odd_uint()` is renamed to `random_odd_integer()`, takes a `NonZeroU32` for `bit_length`. ([#38])
+- All bit length-type parameters take `u32` instead of `usize`. ([#36])
+- All the API is based on the `Integer` trait instead of `Uint` specifically. ([#38])
 
 
 [#36]: https://github.com/entropyxyz/crypto-primes/pull/36

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,14 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.73"
 
 [dependencies]
-crypto-bigint = { version = "0.6.0-pre.6", default-features = false, features = ["rand_core"] }
+crypto-bigint = { version = "0.6.0-pre.7", default-features = false, features = ["rand_core"] }
 rand_core = { version = "0.6.4", default-features = false }
 openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
 rug = { version = "1.18", default-features = false, features = ["integer"], optional = true }
 
 [dev-dependencies]
+# need `crypto-bigint` with `alloc` to test `BoxedUint`
+crypto-bigint = { version = "0.6.0-pre.7", default-features = false, features = ["alloc"] }
 rand_chacha = "0.3"
 criterion = { version = "0.4", features = ["html_reports"] }
 num-modular = { version = "0.5", features = ["num-bigint"] }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,7 +1,7 @@
 use core::num::NonZeroU32;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use crypto_bigint::{nlimbs, Integer, Odd, RandomBits, Uint, U1024, U128, U256};
+use crypto_bigint::{nlimbs, BoxedUint, Integer, Odd, RandomBits, Uint, U1024, U128, U256};
 use rand_chacha::ChaCha8Rng;
 use rand_core::{CryptoRngCore, OsRng, SeedableRng};
 
@@ -236,6 +236,17 @@ fn bench_presets(c: &mut Criterion) {
     let mut rng = make_rng();
     group.bench_function("(U1024) Random safe prime", |b| {
         b.iter(|| generate_safe_prime_with_rng::<U1024>(&mut rng, 1024, 1024))
+    });
+
+    let mut rng = make_rng();
+    group.bench_function("(Boxed128) Random safe prime", |b| {
+        b.iter(|| generate_safe_prime_with_rng::<BoxedUint>(&mut rng, 128, 128))
+    });
+
+    group.sample_size(20);
+    let mut rng = make_rng();
+    group.bench_function("(Boxed1024) Random safe prime", |b| {
+        b.iter(|| generate_safe_prime_with_rng::<BoxedUint>(&mut rng, 1024, 1024))
     });
 
     group.finish();

--- a/src/hazmat/jacobi.rs
+++ b/src/hazmat/jacobi.rs
@@ -84,7 +84,7 @@ pub(crate) fn jacobi_symbol_vartime<T: Integer>(
     };
 
     // A degenerate case.
-    if abs_a == 1 || p_long.as_ref() == &T::one() {
+    if abs_a == 1 || p_long.as_ref() == &T::one_like(p_long) {
         return result;
     }
 

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -192,7 +192,7 @@ fn _is_prime_with_rng<T: Integer + RandomMod>(rng: &mut impl CryptoRngCore, num:
 
 #[cfg(test)]
 mod tests {
-    use crypto_bigint::{CheckedAdd, Uint, Word, U128, U64};
+    use crypto_bigint::{BoxedUint, CheckedAdd, Uint, Word, U128, U64};
     use num_prime::nt_funcs::is_prime64;
     use rand_core::OsRng;
 
@@ -280,9 +280,27 @@ mod tests {
     }
 
     #[test]
+    fn prime_generation_boxed() {
+        for bit_length in (28..=128).step_by(10) {
+            let p: BoxedUint = generate_prime(bit_length, 128);
+            assert!(p.bits_vartime() == bit_length);
+            assert!(is_prime(&p));
+        }
+    }
+
+    #[test]
     fn safe_prime_generation() {
         for bit_length in (28..=128).step_by(10) {
             let p: U128 = generate_safe_prime(bit_length, U128::BITS);
+            assert!(p.bits_vartime() == bit_length);
+            assert!(is_safe_prime(&p));
+        }
+    }
+
+    #[test]
+    fn safe_prime_generation_boxed() {
+        for bit_length in (28..=128).step_by(10) {
+            let p: BoxedUint = generate_safe_prime(bit_length, 128);
             assert!(p.bits_vartime() == bit_length);
             assert!(is_safe_prime(&p));
         }

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -1,6 +1,6 @@
 use core::num::NonZeroU32;
 
-use crypto_bigint::{Integer, Odd, RandomBits, RandomMod};
+use crypto_bigint::{Integer, Limb, Odd, RandomBits, RandomMod};
 use rand_core::CryptoRngCore;
 
 #[cfg(feature = "default-rng")]
@@ -15,8 +15,11 @@ use crate::hazmat::{
 ///
 /// See [`is_prime_with_rng`] for details about the performed checks.
 #[cfg(feature = "default-rng")]
-pub fn generate_prime<T: Integer + RandomBits + RandomMod>(bit_length: u32) -> T {
-    generate_prime_with_rng(&mut OsRng, bit_length)
+pub fn generate_prime<T: Integer + RandomBits + RandomMod>(
+    bit_length: u32,
+    bits_precision: u32,
+) -> T {
+    generate_prime_with_rng(&mut OsRng, bit_length, bits_precision)
 }
 
 /// Returns a random safe prime (that is, such that `(n - 1) / 2` is also prime)
@@ -25,8 +28,11 @@ pub fn generate_prime<T: Integer + RandomBits + RandomMod>(bit_length: u32) -> T
 ///
 /// See [`is_prime_with_rng`] for details about the performed checks.
 #[cfg(feature = "default-rng")]
-pub fn generate_safe_prime<T: Integer + RandomBits + RandomMod>(bit_length: u32) -> T {
-    generate_safe_prime_with_rng(&mut OsRng, bit_length)
+pub fn generate_safe_prime<T: Integer + RandomBits + RandomMod>(
+    bit_length: u32,
+    bits_precision: u32,
+) -> T {
+    generate_safe_prime_with_rng(&mut OsRng, bit_length, bits_precision)
 }
 
 /// Checks probabilistically if the given number is prime using [`OsRng`] as the RNG.
@@ -56,13 +62,14 @@ pub fn is_safe_prime<T: Integer + RandomMod>(num: &T) -> bool {
 pub fn generate_prime_with_rng<T: Integer + RandomBits + RandomMod>(
     rng: &mut impl CryptoRngCore,
     bit_length: u32,
+    bits_precision: u32,
 ) -> T {
     if bit_length < 2 {
         panic!("`bit_length` must be 2 or greater.");
     }
     let bit_length = NonZeroU32::new(bit_length).expect("`bit_length` should be non-zero");
     loop {
-        let start = random_odd_integer::<T>(rng, bit_length);
+        let start = random_odd_integer::<T>(rng, bit_length, bits_precision);
         let sieve = Sieve::new(start.as_ref(), bit_length, false);
         for num in sieve {
             if is_prime_with_rng(rng, &num) {
@@ -82,13 +89,14 @@ pub fn generate_prime_with_rng<T: Integer + RandomBits + RandomMod>(
 pub fn generate_safe_prime_with_rng<T: Integer + RandomBits + RandomMod>(
     rng: &mut impl CryptoRngCore,
     bit_length: u32,
+    bits_precision: u32,
 ) -> T {
     if bit_length < 3 {
         panic!("`bit_length` must be 3 or greater.");
     }
     let bit_length = NonZeroU32::new(bit_length).expect("`bit_length` should be non-zero");
     loop {
-        let start = random_odd_integer::<T>(rng, bit_length);
+        let start = random_odd_integer::<T>(rng, bit_length, bits_precision);
         let sieve = Sieve::new(start.as_ref(), bit_length, true);
         for num in sieve {
             if is_safe_prime_with_rng(rng, &num) {
@@ -124,7 +132,7 @@ pub fn generate_safe_prime_with_rng<T: Integer + RandomBits + RandomMod>(
 ///       Math. Comp. 90 1931-1955 (2021),
 ///       DOI: [10.1090/mcom/3616](https://doi.org/10.1090/mcom/3616)
 pub fn is_prime_with_rng<T: Integer + RandomMod>(rng: &mut impl CryptoRngCore, num: &T) -> bool {
-    if num == &T::from(2u32) {
+    if num == &T::from_limb_like(Limb::from(2u32), num) {
         return true;
     }
 
@@ -146,7 +154,7 @@ pub fn is_safe_prime_with_rng<T: Integer + RandomMod>(
     // Since, by the definition of safe prime, `(num - 1) / 2` must also be prime,
     // and therefore odd, `num` has to be equal to 3 modulo 4.
     // 5 is the only exception, so we check for it.
-    if num == &T::from(5u32) {
+    if num == &T::from_limb_like(Limb::from(5u32), num) {
         return true;
     }
     if num.as_ref()[0].0 & 3 != 3 {
@@ -265,7 +273,7 @@ mod tests {
     #[test]
     fn prime_generation() {
         for bit_length in (28..=128).step_by(10) {
-            let p: U128 = generate_prime(bit_length);
+            let p: U128 = generate_prime(bit_length, U128::BITS);
             assert!(p.bits_vartime() == bit_length);
             assert!(is_prime(&p));
         }
@@ -274,7 +282,7 @@ mod tests {
     #[test]
     fn safe_prime_generation() {
         for bit_length in (28..=128).step_by(10) {
-            let p: U128 = generate_safe_prime(bit_length);
+            let p: U128 = generate_safe_prime(bit_length, U128::BITS);
             assert!(p.bits_vartime() == bit_length);
             assert!(is_safe_prime(&p));
         }
@@ -307,29 +315,29 @@ mod tests {
     #[test]
     #[should_panic(expected = "`bit_length` must be 2 or greater")]
     fn generate_prime_too_few_bits() {
-        let _p: U64 = generate_prime_with_rng(&mut OsRng, 1);
+        let _p: U64 = generate_prime_with_rng(&mut OsRng, 1, U64::BITS);
     }
 
     #[test]
     #[should_panic(expected = "`bit_length` must be 3 or greater")]
     fn generate_safe_prime_too_few_bits() {
-        let _p: U64 = generate_safe_prime_with_rng(&mut OsRng, 2);
+        let _p: U64 = generate_safe_prime_with_rng(&mut OsRng, 2, U64::BITS);
     }
 
     #[test]
     #[should_panic(
-        expected = "try_random_bits() failed: BitLengthTooLarge { bit_length: 65, bits_precision: 64 }"
+        expected = "try_random_bits_with_precision() failed: BitLengthTooLarge { bit_length: 65, bits_precision: 64 }"
     )]
     fn generate_prime_too_many_bits() {
-        let _p: U64 = generate_prime_with_rng(&mut OsRng, 65);
+        let _p: U64 = generate_prime_with_rng(&mut OsRng, 65, U64::BITS);
     }
 
     #[test]
     #[should_panic(
-        expected = "try_random_bits() failed: BitLengthTooLarge { bit_length: 65, bits_precision: 64 }"
+        expected = "try_random_bits_with_precision() failed: BitLengthTooLarge { bit_length: 65, bits_precision: 64 }"
     )]
     fn generate_safe_prime_too_many_bits() {
-        let _p: U64 = generate_safe_prime_with_rng(&mut OsRng, 65);
+        let _p: U64 = generate_safe_prime_with_rng(&mut OsRng, 65, U64::BITS);
     }
 
     fn is_prime_ref(num: Word) -> bool {
@@ -340,7 +348,7 @@ mod tests {
     fn corner_cases_generate_prime() {
         for bits in 2..5 {
             for _ in 0..100 {
-                let p: U64 = generate_prime(bits);
+                let p: U64 = generate_prime(bits, U64::BITS);
                 let p_word = p.as_words()[0];
                 assert!(is_prime_ref(p_word));
             }
@@ -351,7 +359,7 @@ mod tests {
     fn corner_cases_generate_safe_prime() {
         for bits in 3..5 {
             for _ in 0..100 {
-                let p: U64 = generate_safe_prime(bits);
+                let p: U64 = generate_safe_prime(bits, U64::BITS);
                 let p_word = p.as_words()[0];
                 assert!(is_prime_ref(p_word) && is_prime_ref(p_word / 2));
             }
@@ -390,7 +398,7 @@ mod tests_openssl {
 
         // Generate primes, let OpenSSL check them
         for _ in 0..100 {
-            let p: U128 = generate_prime(128);
+            let p: U128 = generate_prime(128, U128::BITS);
             let p_bn = to_openssl(&p);
             assert!(
                 openssl_is_prime(&p_bn, &mut ctx),
@@ -408,7 +416,8 @@ mod tests_openssl {
 
         // Generate random numbers, check if our test agrees with OpenSSL
         for _ in 0..100 {
-            let p = random_odd_integer::<U128>(&mut OsRng, NonZeroU32::new(128).unwrap());
+            let p =
+                random_odd_integer::<U128>(&mut OsRng, NonZeroU32::new(128).unwrap(), U128::BITS);
             let actual = is_prime(p.as_ref());
             let p_bn = to_openssl(&p);
             let expected = openssl_is_prime(&p_bn, &mut ctx);
@@ -451,14 +460,15 @@ mod tests_gmp {
     fn gmp_cross_check() {
         // Generate primes, let GMP check them
         for _ in 0..100 {
-            let p: U128 = generate_prime(128);
+            let p: U128 = generate_prime(128, U128::BITS);
             let p_bn = to_gmp(&p);
             assert!(gmp_is_prime(&p_bn), "GMP reports {p} as composite");
         }
 
         // Generate primes with GMP, check them
         for _ in 0..100 {
-            let start = random_odd_integer::<U128>(&mut OsRng, NonZeroU32::new(128).unwrap());
+            let start =
+                random_odd_integer::<U128>(&mut OsRng, NonZeroU32::new(128).unwrap(), U128::BITS);
             let start_bn = to_gmp(&start);
             let p_bn = start_bn.next_prime();
             let p = from_gmp(&p_bn);
@@ -467,7 +477,8 @@ mod tests_gmp {
 
         // Generate random numbers, check if our test agrees with GMP
         for _ in 0..100 {
-            let p = random_odd_integer::<U128>(&mut OsRng, NonZeroU32::new(128).unwrap());
+            let p =
+                random_odd_integer::<U128>(&mut OsRng, NonZeroU32::new(128).unwrap(), U128::BITS);
             let actual = is_prime(p.as_ref());
             let p_bn = to_gmp(&p);
             let expected = gmp_is_prime(&p_bn);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,7 +15,11 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self;
+    fn generate_prime_with_rng(
+        rng: &mut impl CryptoRngCore,
+        bit_length: u32,
+        bits_precision: u32,
+    ) -> Self;
 
     /// Returns a random safe prime (that is, such that `(n - 1) / 2` is also prime)
     /// of size `bit_length` using the provided RNG.
@@ -24,7 +28,11 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 3, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self;
+    fn generate_safe_prime_with_rng(
+        rng: &mut impl CryptoRngCore,
+        bit_length: u32,
+        bits_precision: u32,
+    ) -> Self;
 
     /// Checks probabilistically if the given number is prime using the provided RNG.
     ///
@@ -38,11 +46,19 @@ pub trait RandomPrimeWithRng {
 }
 
 impl<T: Integer + RandomBits + RandomMod> RandomPrimeWithRng for T {
-    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
-        generate_prime_with_rng(rng, bit_length)
+    fn generate_prime_with_rng(
+        rng: &mut impl CryptoRngCore,
+        bit_length: u32,
+        bits_precision: u32,
+    ) -> Self {
+        generate_prime_with_rng(rng, bit_length, bits_precision)
     }
-    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
-        generate_safe_prime_with_rng(rng, bit_length)
+    fn generate_safe_prime_with_rng(
+        rng: &mut impl CryptoRngCore,
+        bit_length: u32,
+        bits_precision: u32,
+    ) -> Self {
+        generate_safe_prime_with_rng(rng, bit_length, bits_precision)
     }
     fn is_prime_with_rng(&self, rng: &mut impl CryptoRngCore) -> bool {
         is_prime_with_rng(rng, self)
@@ -67,9 +83,10 @@ mod tests {
         assert!(!U64::from(13u32).is_safe_prime_with_rng(&mut OsRng));
         assert!(U64::from(11u32).is_safe_prime_with_rng(&mut OsRng));
 
-        assert!(U64::generate_prime_with_rng(&mut OsRng, 10).is_prime_with_rng(&mut OsRng));
         assert!(
-            U64::generate_safe_prime_with_rng(&mut OsRng, 10).is_safe_prime_with_rng(&mut OsRng)
+            U64::generate_prime_with_rng(&mut OsRng, 10, U64::BITS).is_prime_with_rng(&mut OsRng)
         );
+        assert!(U64::generate_safe_prime_with_rng(&mut OsRng, 10, U64::BITS)
+            .is_safe_prime_with_rng(&mut OsRng));
     }
 }


### PR DESCRIPTION
This may supersede #39. It uses `*_like` constructors (see https://github.com/RustCrypto/crypto-bigint/pull/533) instead of automatic widening, which I think is a safer approach. 

The 1024 bit safe prime generation is about 30% slower for `BoxedUint` compared to `Uint`. Not too bad for a start, but clearly there is room for improvement.

@xuganyu96 sorry, tried to base it on your PR, but I guess I changed the first commit too much, and it's not assigned to you anymore.