### PR TITLE
Remove bit precision from the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bumped `crypto-bigint` to 0.6.0-rc.6 (pinned) and MSRV to 1.81. ([#55])
-
+- Remove bit precision from the public API ([#46])
 
 [#55]: https://github.com/entropyxyz/crypto-primes/pull/55
+[#46]: https://github.com/entropyxyz/crypto-primes/pull/46
 
 
 ## [0.6.0-pre.1] - 2024-10-03

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,20 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.73"
 
 [dependencies]
-crypto-bigint = { version = "0.6.0-pre.7", default-features = false, features = ["rand_core", "zeroize"] }
+crypto-bigint = { version = "0.6.0-pre.7", default-features = false, features = [
+	"rand_core",
+] }
 rand_core = { version = "0.6.4", default-features = false }
 openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
-rug = { version = "1.26", default-features = false, features = ["integer"], optional = true }
+rug = { version = "1.26", default-features = false, features = [
+	"integer",
+], optional = true }
 
 [dev-dependencies]
 # need `crypto-bigint` with `alloc` to test `BoxedUint`
-crypto-bigint = { version = "0.6.0-pre.7", default-features = false, features = ["alloc"] }
+crypto-bigint = { version = "0.6.0-pre.7", default-features = false, features = [
+	"alloc",
+] }
 rand_chacha = "0.3"
 criterion = { version = "0.5", features = ["html_reports"] }
 num-modular = { version = "0.5", features = ["num-bigint"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.73"
 
 [dependencies]
-crypto-bigint = { version = "0.6.0-pre.7", default-features = false, features = ["rand_core"] }
+crypto-bigint = { version = "0.6.0-pre.7", default-features = false, features = ["rand_core", "zeroize"] }
 rand_core = { version = "0.6.4", default-features = false }
 openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
 rug = { version = "1.26", default-features = false, features = ["integer"], optional = true }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -34,7 +34,11 @@ fn random_odd_uint<T: RandomBits + Integer>(
 
 fn make_sieve<const L: usize>(rng: &mut impl CryptoRngCore) -> Sieve<Uint<L>> {
     let start = random_odd_uint::<Uint<L>>(rng, Uint::<L>::BITS, Uint::<L>::BITS);
-    Sieve::new(&start, NonZeroU32::new(Uint::<L>::BITS).unwrap(), false)
+    Sieve::new(
+        start.get(),
+        NonZeroU32::new(Uint::<L>::BITS).unwrap(),
+        false,
+    )
 }
 
 fn make_presieved_num<const L: usize>(rng: &mut impl CryptoRngCore) -> Odd<Uint<L>> {
@@ -52,7 +56,7 @@ fn bench_sieve(c: &mut Criterion) {
     group.bench_function("(U128) creation", |b| {
         b.iter_batched(
             || random_odd_uint::<U128>(&mut OsRng, 128, 128),
-            |start| Sieve::new(start.as_ref(), NonZeroU32::new(128).unwrap(), false),
+            |start| Sieve::new(start.get(), NonZeroU32::new(128).unwrap(), false),
             BatchSize::SmallInput,
         )
     });
@@ -73,7 +77,7 @@ fn bench_sieve(c: &mut Criterion) {
     group.bench_function("(U1024) creation", |b| {
         b.iter_batched(
             || random_odd_uint::<U1024>(&mut OsRng, 1024, 1024),
-            |start| Sieve::new(start.as_ref(), NonZeroU32::new(1024).unwrap(), false),
+            |start| Sieve::new(start.get(), NonZeroU32::new(1024).unwrap(), false),
             BatchSize::SmallInput,
         )
     });
@@ -95,14 +99,14 @@ fn bench_miller_rabin(c: &mut Criterion) {
     group.bench_function("(U128) creation", |b| {
         b.iter_batched(
             || random_odd_uint::<U128>(&mut OsRng, 128, 128),
-            |n| MillerRabin::new(&n),
+            |n| MillerRabin::new(n),
             BatchSize::SmallInput,
         )
     });
 
     group.bench_function("(U128) random base test (pre-sieved)", |b| {
         b.iter_batched(
-            || MillerRabin::new(&make_presieved_num::<{ nlimbs!(128) }>(&mut OsRng)),
+            || MillerRabin::new(make_presieved_num::<{ nlimbs!(128) }>(&mut OsRng)),
             |mr| mr.test_random_base(&mut OsRng),
             BatchSize::SmallInput,
         )
@@ -111,14 +115,14 @@ fn bench_miller_rabin(c: &mut Criterion) {
     group.bench_function("(U1024) creation", |b| {
         b.iter_batched(
             || random_odd_uint::<U1024>(&mut OsRng, 1024, 1024),
-            |n| MillerRabin::new(&n),
+            |n| MillerRabin::new(n),
             BatchSize::SmallInput,
         )
     });
 
     group.bench_function("(U1024) random base test (pre-sieved)", |b| {
         b.iter_batched(
-            || MillerRabin::new(&make_presieved_num::<{ nlimbs!(1024) }>(&mut OsRng)),
+            || MillerRabin::new(make_presieved_num::<{ nlimbs!(1024) }>(&mut OsRng)),
             |mr| mr.test_random_base(&mut OsRng),
             BatchSize::SmallInput,
         )

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -27,13 +27,12 @@ fn make_rng() -> ChaCha8Rng {
 fn random_odd_uint<T: RandomBits + Integer>(
     rng: &mut impl CryptoRngCore,
     bit_length: u32,
-    bits_precision: u32,
 ) -> Odd<T> {
-    random_odd_integer::<T>(rng, NonZeroU32::new(bit_length).unwrap(), bits_precision)
+    random_odd_integer::<T>(rng, NonZeroU32::new(bit_length).unwrap())
 }
 
 fn make_sieve<const L: usize>(rng: &mut impl CryptoRngCore) -> Sieve<Uint<L>> {
-    let start = random_odd_uint::<Uint<L>>(rng, Uint::<L>::BITS, Uint::<L>::BITS);
+    let start = random_odd_uint::<Uint<L>>(rng, Uint::<L>::BITS);
     Sieve::new(
         start.get(),
         NonZeroU32::new(Uint::<L>::BITS).unwrap(),
@@ -50,12 +49,12 @@ fn bench_sieve(c: &mut Criterion) {
     let mut group = c.benchmark_group("Sieve");
 
     group.bench_function("(U128) random start", |b| {
-        b.iter(|| random_odd_uint::<U128>(&mut OsRng, 128, 128))
+        b.iter(|| random_odd_uint::<U128>(&mut OsRng, 128))
     });
 
     group.bench_function("(U128) creation", |b| {
         b.iter_batched(
-            || random_odd_uint::<U128>(&mut OsRng, 128, 128),
+            || random_odd_uint::<U128>(&mut OsRng, 128),
             |start| Sieve::new(start.get(), NonZeroU32::new(128).unwrap(), false),
             BatchSize::SmallInput,
         )
@@ -71,12 +70,12 @@ fn bench_sieve(c: &mut Criterion) {
     });
 
     group.bench_function("(U1024) random start", |b| {
-        b.iter(|| random_odd_uint::<U1024>(&mut OsRng, 1024, 1024))
+        b.iter(|| random_odd_uint::<U1024>(&mut OsRng, 1024))
     });
 
     group.bench_function("(U1024) creation", |b| {
         b.iter_batched(
-            || random_odd_uint::<U1024>(&mut OsRng, 1024, 1024),
+            || random_odd_uint::<U1024>(&mut OsRng, 1024),
             |start| Sieve::new(start.get(), NonZeroU32::new(1024).unwrap(), false),
             BatchSize::SmallInput,
         )
@@ -98,7 +97,7 @@ fn bench_miller_rabin(c: &mut Criterion) {
 
     group.bench_function("(U128) creation", |b| {
         b.iter_batched(
-            || random_odd_uint::<U128>(&mut OsRng, 128, 128),
+            || random_odd_uint::<U128>(&mut OsRng, 128),
             |n| MillerRabin::new(n),
             BatchSize::SmallInput,
         )
@@ -114,7 +113,7 @@ fn bench_miller_rabin(c: &mut Criterion) {
 
     group.bench_function("(U1024) creation", |b| {
         b.iter_batched(
-            || random_odd_uint::<U1024>(&mut OsRng, 1024, 1024),
+            || random_odd_uint::<U1024>(&mut OsRng, 1024),
             |n| MillerRabin::new(n),
             BatchSize::SmallInput,
         )
@@ -136,7 +135,7 @@ fn bench_lucas(c: &mut Criterion) {
     group.bench_function("(U128) Selfridge base, strong check (pre-sieved)", |b| {
         b.iter_batched(
             || make_presieved_num::<{ nlimbs!(128) }>(&mut rng),
-            |n| lucas_test(&n, SelfridgeBase, LucasCheck::Strong),
+            |n| lucas_test(n, SelfridgeBase, LucasCheck::Strong),
             BatchSize::SmallInput,
         )
     });
@@ -145,7 +144,7 @@ fn bench_lucas(c: &mut Criterion) {
     group.bench_function("(U1024) Selfridge base, strong check (pre-sieved)", |b| {
         b.iter_batched(
             || make_presieved_num::<{ nlimbs!(1024) }>(&mut rng),
-            |n| lucas_test(&n, SelfridgeBase, LucasCheck::Strong),
+            |n| lucas_test(n, SelfridgeBase, LucasCheck::Strong),
             BatchSize::SmallInput,
         )
     });
@@ -154,7 +153,7 @@ fn bench_lucas(c: &mut Criterion) {
     group.bench_function("(U1024) A* base, Lucas-V check (pre-sieved)", |b| {
         b.iter_batched(
             || make_presieved_num::<{ nlimbs!(1024) }>(&mut rng),
-            |n| lucas_test(&n, AStarBase, LucasCheck::LucasV),
+            |n| lucas_test(n, AStarBase, LucasCheck::LucasV),
             BatchSize::SmallInput,
         )
     });
@@ -165,7 +164,7 @@ fn bench_lucas(c: &mut Criterion) {
         |b| {
             b.iter_batched(
                 || make_presieved_num::<{ nlimbs!(1024) }>(&mut rng),
-                |n| lucas_test(&n, BruteForceBase, LucasCheck::AlmostExtraStrong),
+                |n| lucas_test(n, BruteForceBase, LucasCheck::AlmostExtraStrong),
                 BatchSize::SmallInput,
             )
         },
@@ -175,7 +174,7 @@ fn bench_lucas(c: &mut Criterion) {
     group.bench_function("(U1024) brute force base, extra strong (pre-sieved)", |b| {
         b.iter_batched(
             || make_presieved_num::<{ nlimbs!(1024) }>(&mut rng),
-            |n| lucas_test(&n, BruteForceBase, LucasCheck::ExtraStrong),
+            |n| lucas_test(n, BruteForceBase, LucasCheck::ExtraStrong),
             BatchSize::SmallInput,
         )
     });
@@ -195,7 +194,7 @@ fn bench_lucas(c: &mut Criterion) {
 
     group.bench_function("(U1024) Selfridge base, strong check, slow path", |b| {
         b.iter(|| {
-            lucas_test(&slow_path, SelfridgeBase, LucasCheck::Strong);
+            lucas_test(slow_path, SelfridgeBase, LucasCheck::Strong);
         })
     });
 
@@ -207,7 +206,7 @@ fn bench_presets(c: &mut Criterion) {
 
     group.bench_function("(U128) Prime test", |b| {
         b.iter_batched(
-            || random_odd_uint::<U128>(&mut OsRng, 128, 128),
+            || random_odd_uint::<U128>(&mut OsRng, 128),
             |num| is_prime_with_rng(&mut OsRng, num.as_ref()),
             BatchSize::SmallInput,
         )
@@ -215,7 +214,7 @@ fn bench_presets(c: &mut Criterion) {
 
     group.bench_function("(U128) Safe prime test", |b| {
         b.iter_batched(
-            || random_odd_uint::<U128>(&mut OsRng, 128, 128),
+            || random_odd_uint::<U128>(&mut OsRng, 128),
             |num| is_safe_prime_with_rng(&mut OsRng, num.as_ref()),
             BatchSize::SmallInput,
         )
@@ -223,34 +222,34 @@ fn bench_presets(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random prime", |b| {
-        b.iter(|| generate_prime_with_rng::<U128>(&mut rng, 128, 128))
+        b.iter(|| generate_prime_with_rng::<U128>(&mut rng, 128))
     });
 
     let mut rng = make_rng();
     group.bench_function("(U1024) Random prime", |b| {
-        b.iter(|| generate_prime_with_rng::<U1024>(&mut rng, 1024, 1024))
+        b.iter(|| generate_prime_with_rng::<U1024>(&mut rng, 1024))
     });
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random safe prime", |b| {
-        b.iter(|| generate_safe_prime_with_rng::<U128>(&mut rng, 128, 128))
+        b.iter(|| generate_safe_prime_with_rng::<U128>(&mut rng, 128))
     });
 
     group.sample_size(20);
     let mut rng = make_rng();
     group.bench_function("(U1024) Random safe prime", |b| {
-        b.iter(|| generate_safe_prime_with_rng::<U1024>(&mut rng, 1024, 1024))
+        b.iter(|| generate_safe_prime_with_rng::<U1024>(&mut rng, 1024))
     });
 
     let mut rng = make_rng();
     group.bench_function("(Boxed128) Random safe prime", |b| {
-        b.iter(|| generate_safe_prime_with_rng::<BoxedUint>(&mut rng, 128, 128))
+        b.iter(|| generate_safe_prime_with_rng::<BoxedUint>(&mut rng, 128))
     });
 
     group.sample_size(20);
     let mut rng = make_rng();
     group.bench_function("(Boxed1024) Random safe prime", |b| {
-        b.iter(|| generate_safe_prime_with_rng::<BoxedUint>(&mut rng, 1024, 1024))
+        b.iter(|| generate_safe_prime_with_rng::<BoxedUint>(&mut rng, 1024))
     });
 
     group.finish();
@@ -260,19 +259,19 @@ fn bench_presets(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random safe prime", |b| {
-        b.iter(|| generate_safe_prime_with_rng::<U128>(&mut rng, 128, 128))
+        b.iter(|| generate_safe_prime_with_rng::<U128>(&mut rng, 128))
     });
 
     // The performance should scale with the prime size, not with the Uint size.
     // So we should strive for this test's result to be as close as possible
     // to that of the previous one and as far away as possible from the next one.
     group.bench_function("(U256) Random 128 bit safe prime", |b| {
-        b.iter(|| generate_safe_prime_with_rng::<U256>(&mut rng, 128, 256))
+        b.iter(|| generate_safe_prime_with_rng::<U256>(&mut rng, 128))
     });
 
     // The upper bound for the previous test.
     group.bench_function("(U256) Random 256 bit safe prime", |b| {
-        b.iter(|| generate_safe_prime_with_rng::<U256>(&mut rng, 256, 256))
+        b.iter(|| generate_safe_prime_with_rng::<U256>(&mut rng, 256))
     });
 
     group.finish();

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -98,7 +98,7 @@ fn bench_miller_rabin(c: &mut Criterion) {
     group.bench_function("(U128) creation", |b| {
         b.iter_batched(
             || random_odd_uint::<U128>(&mut OsRng, 128),
-            |n| MillerRabin::new(n),
+            MillerRabin::<U128>::new,
             BatchSize::SmallInput,
         )
     });
@@ -114,7 +114,7 @@ fn bench_miller_rabin(c: &mut Criterion) {
     group.bench_function("(U1024) creation", |b| {
         b.iter_batched(
             || random_odd_uint::<U1024>(&mut OsRng, 1024),
-            |n| MillerRabin::new(n),
+            MillerRabin::<U1024>::new,
             BatchSize::SmallInput,
         )
     });

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -282,7 +282,7 @@ fn bench_gmp(c: &mut Criterion) {
     let mut group = c.benchmark_group("GMP");
 
     fn random<const L: usize>(rng: &mut impl CryptoRngCore) -> GmpInteger {
-        let num = random_odd_uint::<Uint<L>>(rng, Uint::<L>::BITS, Uint::<L>::BITS).get();
+        let num = random_odd_uint::<Uint<L>>(rng, Uint::<L>::BITS).get();
         GmpInteger::from_digits(num.as_words(), Order::Lsf)
     }
 

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -10,7 +10,7 @@ use super::{
 /// The maximum number of attempts to find `D` such that `(D/n) == -1`.
 // This is widely believed to be impossible.
 // So if we exceed it, we will panic reporting the value of `n`.
-const MAX_ATTEMPTS: usize = 10000;
+const MAX_ATTEMPTS: usize = 10_000;
 
 /// The number of attempts to find `D` such that `(D/n) == -1`
 /// before checking that `n` is a square (in which case such `D` does not exist).

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -869,36 +869,30 @@ mod tests {
 
             let odd_num = Odd::new(Uint::<1>::from(num)).unwrap();
 
-            let res = lucas_test(
-                odd_num.clone(),
-                BruteForceBase,
-                LucasCheck::AlmostExtraStrong,
-            )
-            .is_probably_prime();
+            let res = lucas_test(odd_num, BruteForceBase, LucasCheck::AlmostExtraStrong)
+                .is_probably_prime();
             let expected = aeslpsp || res_ref;
             assert_eq!(
                 res, expected,
                 "Brute force base, almost extra strong: n={num}, expected={expected}, actual={res}",
             );
 
-            let res = lucas_test(odd_num.clone(), BruteForceBase, LucasCheck::ExtraStrong)
-                .is_probably_prime();
+            let res =
+                lucas_test(odd_num, BruteForceBase, LucasCheck::ExtraStrong).is_probably_prime();
             let expected = eslpsp || res_ref;
             assert_eq!(
                 res, expected,
                 "Brute force base: n={num}, expected={expected}, actual={res}",
             );
 
-            let res =
-                lucas_test(odd_num.clone(), SelfridgeBase, LucasCheck::Strong).is_probably_prime();
+            let res = lucas_test(odd_num, SelfridgeBase, LucasCheck::Strong).is_probably_prime();
             let expected = slpsp || res_ref;
             assert_eq!(
                 res, expected,
                 "Selfridge base: n={num}, expected={expected}, actual={res}",
             );
 
-            let res =
-                lucas_test(odd_num.clone(), AStarBase, LucasCheck::LucasV).is_probably_prime();
+            let res = lucas_test(odd_num, AStarBase, LucasCheck::LucasV).is_probably_prime();
             let expected = vpsp || res_ref;
 
             assert_eq!(

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -335,7 +335,7 @@ pub fn lucas_test<T: Integer>(
     // it does not noticeably affect the performance.
     if abs_q != 1
         && gcd_vartime(candidate.as_ref(), abs_q) != 1
-        && candidate.as_ref() > &to_integer(abs_q)
+        && candidate.as_ref().as_ref()[0].0 > abs_q
     {
         return Primality::Composite;
     }

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -869,30 +869,36 @@ mod tests {
 
             let odd_num = Odd::new(Uint::<1>::from(num)).unwrap();
 
-            let res = lucas_test(&odd_num, BruteForceBase, LucasCheck::AlmostExtraStrong)
-                .is_probably_prime();
+            let res = lucas_test(
+                odd_num.clone(),
+                BruteForceBase,
+                LucasCheck::AlmostExtraStrong,
+            )
+            .is_probably_prime();
             let expected = aeslpsp || res_ref;
             assert_eq!(
                 res, expected,
                 "Brute force base, almost extra strong: n={num}, expected={expected}, actual={res}",
             );
 
-            let res =
-                lucas_test(&odd_num, BruteForceBase, LucasCheck::ExtraStrong).is_probably_prime();
+            let res = lucas_test(odd_num.clone(), BruteForceBase, LucasCheck::ExtraStrong)
+                .is_probably_prime();
             let expected = eslpsp || res_ref;
             assert_eq!(
                 res, expected,
                 "Brute force base: n={num}, expected={expected}, actual={res}",
             );
 
-            let res = lucas_test(&odd_num, SelfridgeBase, LucasCheck::Strong).is_probably_prime();
+            let res =
+                lucas_test(odd_num.clone(), SelfridgeBase, LucasCheck::Strong).is_probably_prime();
             let expected = slpsp || res_ref;
             assert_eq!(
                 res, expected,
                 "Selfridge base: n={num}, expected={expected}, actual={res}",
             );
 
-            let res = lucas_test(&odd_num, AStarBase, LucasCheck::LucasV).is_probably_prime();
+            let res =
+                lucas_test(odd_num.clone(), AStarBase, LucasCheck::LucasV).is_probably_prime();
             let expected = vpsp || res_ref;
 
             assert_eq!(

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -335,7 +335,7 @@ pub fn lucas_test<T: Integer>(
     // it does not noticeably affect the performance.
     if abs_q != 1
         && gcd_vartime(candidate.as_ref(), abs_q) != 1
-        && candidate.as_ref().as_ref()[0].0 > abs_q
+        && candidate.as_ref() > &to_integer(abs_q)
     {
         return Primality::Composite;
     }

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -197,8 +197,7 @@ mod tests {
     #[test]
     fn trivial() {
         let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
-        let start =
-            random_odd_integer::<U1024>(&mut rng, NonZeroU32::new(1024).unwrap(), U1024::BITS);
+        let start = random_odd_integer::<U1024>(&mut rng, NonZeroU32::new(1024).unwrap());
         for num in Sieve::new(start.get(), NonZeroU32::new(1024).unwrap(), false).take(10) {
             let mr = MillerRabin::new(Odd::new(num).unwrap());
 
@@ -295,7 +294,7 @@ mod tests {
 
             let spsp = is_spsp(num);
 
-            let mr = MillerRabin::new(&Odd::new(U64::from(num)).unwrap());
+            let mr = MillerRabin::new(Odd::new(U64::from(num)).unwrap());
             let res = mr.test_base_two().is_probably_prime();
             let expected = spsp || res_ref;
             assert_eq!(

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -69,7 +69,7 @@ impl<T: Integer + RandomMod> MillerRabin<T> {
     }
 
     /// Perform a Miller-Rabin check with a given base.
-    pub fn test(&self, base: T) -> Primality {
+    pub fn test(&self, base: &T) -> Primality {
         // TODO: it may be faster to first check that gcd(base, candidate) == 1,
         // otherwise we can return `Composite` right away.
 
@@ -98,7 +98,7 @@ impl<T: Integer + RandomMod> MillerRabin<T> {
 
     /// Perform a Miller-Rabin check with base 2.
     pub fn test_base_two(&self) -> Primality {
-        self.test(T::from_limb_like(Limb::from(2u32), &self.candidate))
+        self.test(&T::from_limb_like(Limb::from(2u32), &self.candidate))
     }
 
     /// Perform a Miller-Rabin check with a random base (in the range `[3, candidate-2]`)
@@ -122,7 +122,7 @@ impl<T: Integer + RandomMod> MillerRabin<T> {
         let random = T::random_mod(rng, &range_nonzero)
             .checked_add(&T::from(3u32))
             .expect("addition should not overflow by construction");
-        self.test(random)
+        self.test(&random)
     }
 
     /// Returns the number of bits necessary to represent the candidate.
@@ -130,7 +130,7 @@ impl<T: Integer + RandomMod> MillerRabin<T> {
     ///
     /// For example, a U512 type occupies 8 64-bit words, but the number `7` contained in such a type
     /// has a bit length of 3 because 7 is `b111`.
-    pub fn bits(&self) -> u32 {
+    pub(crate) fn bits(&self) -> u32 {
         self.bits
     }
 }
@@ -216,8 +216,8 @@ mod tests {
             let mr = MillerRabin::new(Odd::new(num).unwrap());
 
             // Trivial tests, must always be true.
-            assert!(mr.test(1u32.into()).is_probably_prime());
-            assert!(mr.test(num.wrapping_sub(&1u32.into())).is_probably_prime());
+            assert!(mr.test(&1u32.into()).is_probably_prime());
+            assert!(mr.test(&num.wrapping_sub(&1u32.into())).is_probably_prime());
         }
     }
 
@@ -272,10 +272,10 @@ mod tests {
 
         // It is known to pass MR tests for all prime bases <307
         assert!(mr.test_base_two().is_probably_prime());
-        assert!(mr.test(U1536::from(293u64)).is_probably_prime());
+        assert!(mr.test(&U1536::from(293u64)).is_probably_prime());
 
         // A test with base 307 correctly reports the number as composite.
-        assert!(!mr.test(U1536::from(307u64)).is_probably_prime());
+        assert!(!mr.test(&U1536::from(307u64)).is_probably_prime());
     }
 
     fn test_large_primes<const L: usize>(nums: &[Uint<L>]) {

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -69,7 +69,7 @@ impl<T: Integer> Sieve<T> {
     /// Panics if `max_bit_length` greater than the precision of `start`.
     ///
     /// If `safe_primes` is `true`, both the returned `n` and `n/2` are sieved.
-    pub fn new(start: &T, max_bit_length: NonZeroU32, safe_primes: bool) -> Self {
+    pub fn new(start: T, max_bit_length: NonZeroU32, safe_primes: bool) -> Self {
         let max_bit_length = max_bit_length.get();
 
         if max_bit_length > start.bits_precision() {
@@ -84,7 +84,7 @@ impl<T: Integer> Sieve<T> {
         let (max_bit_length, base) = if safe_primes {
             (max_bit_length - 1, start.wrapping_shr_vartime(1))
         } else {
-            (max_bit_length, start.clone())
+            (max_bit_length, start)
         };
 
         let mut base = base;
@@ -100,7 +100,7 @@ impl<T: Integer> Sieve<T> {
             base = T::from(3u32);
         } else {
             // Adjust the base so that we hit odd numbers when incrementing it by 2.
-            base |= T::one_like(start);
+            base |= T::one();
         }
 
         // Only calculate residues by primes up to and not including `base`,
@@ -285,7 +285,7 @@ mod tests {
         let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
         let start =
             random_odd_integer::<U64>(&mut rng, NonZeroU32::new(32).unwrap(), U64::BITS).get();
-        for num in Sieve::new(&start, NonZeroU32::new(32).unwrap(), false).take(100) {
+        for num in Sieve::new(start, NonZeroU32::new(32).unwrap(), false).take(100) {
             let num_u64 = u64::from(num);
             assert!(num_u64.leading_zeros() == 32);
 
@@ -298,7 +298,7 @@ mod tests {
 
     fn check_sieve(start: u32, bit_length: u32, safe_prime: bool, reference: &[u32]) {
         let test = Sieve::new(
-            &U64::from(start),
+            U64::from(start),
             NonZeroU32::new(bit_length).unwrap(),
             safe_prime,
         )
@@ -359,7 +359,7 @@ mod tests {
         expected = "The requested bit length (65) is larger than the precision of `start`"
     )]
     fn sieve_too_many_bits() {
-        let _sieve = Sieve::new(&U64::ONE, NonZeroU32::new(65).unwrap(), false);
+        let _sieve = Sieve::new(U64::ONE, NonZeroU32::new(65).unwrap(), false);
     }
 
     #[test]
@@ -381,7 +381,7 @@ mod tests {
 
     #[test]
     fn sieve_derived_traits() {
-        let s = Sieve::new(&U64::ONE, NonZeroU32::new(10).unwrap(), false);
+        let s = Sieve::new(U64::ONE, NonZeroU32::new(10).unwrap(), false);
         assert!(format!("{s:?}").starts_with("Sieve"));
         assert_eq!(s.clone(), s);
     }

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -303,7 +303,9 @@ mod tests {
                 .get();
 
         for num in Sieve::new(start, NonZeroU32::new(32).unwrap(), false).take(100) {
-            let num_u64 = num.as_words()[0];
+            // For 32-bit targets
+            #[allow(clippy::useless_conversion)]
+            let num_u64: u64 = num.as_words()[0].into();
             assert!(num_u64.leading_zeros() == 32);
 
             let factors_and_powers = factorize64(num_u64);

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -9,8 +9,11 @@ use rand_core::CryptoRngCore;
 
 use crate::hazmat::precomputed::{SmallPrime, RECIPROCALS, SMALL_PRIMES};
 
-/// Returns a random odd integer with given bit length
-/// (that is, with both `0` and `bit_length-1` bits set).
+/// Returns a random odd integer with given bit length (that is, with both `0` and `bit_length-1`
+/// bits set).
+///
+/// *Panics*: if the `bit_length` is bigger than the bits available in the `Integer`, e.g. 37 for a
+/// `U32`.
 pub fn random_odd_integer<T: Integer + RandomBits>(
     rng: &mut impl CryptoRngCore,
     bit_length: NonZeroU32,
@@ -300,7 +303,7 @@ mod tests {
                 .get();
 
         for num in Sieve::new(start, NonZeroU32::new(32).unwrap(), false).take(100) {
-            let num_u64 = u64::from(num.as_words()[0]);
+            let num_u64 = num.as_words()[0];
             assert!(num_u64.leading_zeros() == 32);
 
             let factors_and_powers = factorize64(num_u64);

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -195,11 +195,7 @@ impl<T: Integer> Sieve<T> {
             // If `(n - 1)/2 mod d == (d - 1)/2`, it means that `n mod d == 0`.
             // In other words, we are checking the remainder of `n mod d`
             // for virtually no additional cost.
-            if r == 0 || (self.safe_primes && r == (d - 1) >> 1) {
-                return true;
-            } else {
-                return false;
-            }
+            r == 0 || (self.safe_primes && r == (d - 1) >> 1)
         })
     }
 

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -9,8 +9,8 @@ use rand_core::CryptoRngCore;
 
 use crate::hazmat::precomputed::{SmallPrime, RECIPROCALS, SMALL_PRIMES};
 
-/// Returns a random odd integer with given bit length (that is, with both `0` and `bit_length-1`
-/// bits set).
+/// Returns a random odd integer with given bit length
+/// (that is, with both `0` and `bit_length-1` bits set).
 ///
 /// *Panics*: if the `bit_length` is bigger than the bits available in the `Integer`, e.g. 37 for a
 /// `U32`.

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -185,13 +185,9 @@ impl<T: Integer> Sieve<T> {
 
     // Returns `true` if the current `base + incr` is divisible by any of the small primes.
     fn current_is_composite(&self) -> bool {
-        for (i, m) in self.residues.iter().enumerate() {
+        self.residues.iter().enumerate().any(|(i, m)| {
             let d = SMALL_PRIMES[i] as Residue;
             let r = (*m as Residue + self.incr) % d;
-
-            if r == 0 {
-                return true;
-            }
 
             // A trick from "Safe Prime Generation with a Combined Sieve" by Michael J. Wiener
             // (https://eprint.iacr.org/2003/186).
@@ -199,12 +195,12 @@ impl<T: Integer> Sieve<T> {
             // If `(n - 1)/2 mod d == (d - 1)/2`, it means that `n mod d == 0`.
             // In other words, we are checking the remainder of `n mod d`
             // for virtually no additional cost.
-            if self.safe_primes && r == (d - 1) >> 1 {
+            if r == 0 || (self.safe_primes && r == (d - 1) >> 1) {
                 return true;
+            } else {
+                return false;
             }
-        }
-
-        false
+        })
     }
 
     // Returns the restored `base + incr` if it is not composite (wrt the small primes),

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -151,8 +151,8 @@ pub fn is_safe_prime_with_rng<T: Integer + RandomMod>(
     }
 
     // These are ensured to be odd by the check above.
-    let odd_num = Odd::new(num.clone()).expect("`num` is be odd here given the checks above");
-    let odd_half_num = Odd::new(num.wrapping_shr_vartime(1)).expect("The binary rep of `num` is `11` so shifting right by one is guaranteed to end in one, so it's odd");
+    let odd_num = Odd::new(num.clone()).expect("`num` is odd here given the checks above");
+    let odd_half_num = Odd::new(num.wrapping_shr_vartime(1)).expect("The binary rep of `num` ends in `11`, so shifting right by one is guaranteed leave a `1` at the end, so it's odd");
 
     _is_prime_with_rng(rng, odd_num) && _is_prime_with_rng(rng, odd_half_num)
 }
@@ -173,7 +173,7 @@ fn _is_prime_with_rng<T: Integer + RandomMod>(rng: &mut impl CryptoRngCore, num:
     }
 
     // The random base test only makes sense when `num > 3`.
-    if mr.bit_length() > 2 && !mr.test_random_base(rng).is_probably_prime() {
+    if mr.bits() > 2 && !mr.test_random_base(rng).is_probably_prime() {
         return false;
     }
 

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -161,9 +161,11 @@ pub fn is_safe_prime_with_rng<T: Integer + RandomMod>(
 /// If the outcome of M-R is "probably prime", then run a Lucas test
 /// If the Lucas test is inconclusive, run a Miller-Rabin with random base and unless this second
 /// M-R test finds it's composite, then conclude that it's prime.
-fn _is_prime_with_rng<T: Integer + RandomMod>(rng: &mut impl CryptoRngCore, num: Odd<T>) -> bool {
-    let candidate = num.clone();
-    let mr = MillerRabin::new(num);
+fn _is_prime_with_rng<T: Integer + RandomMod>(
+    rng: &mut impl CryptoRngCore,
+    candidate: Odd<T>,
+) -> bool {
+    let mr = MillerRabin::new(candidate.clone());
 
     if !mr.test_base_two().is_probably_prime() {
         return false;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -14,11 +14,7 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn generate_prime_with_rng(
-        rng: &mut impl CryptoRngCore,
-        bit_length: u32,
-        bits_precision: u32,
-    ) -> Self;
+    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self;
 
     /// Returns a random safe prime (that is, such that `(n - 1) / 2` is also prime)
     /// of size `bit_length` using the provided RNG.
@@ -26,11 +22,7 @@ pub trait RandomPrimeWithRng {
     /// Panics if `bit_length` is less than 3, or greater than the bit size of the target `Uint`.
     ///
     /// See [`is_prime_with_rng`] for details about the performed checks.
-    fn generate_safe_prime_with_rng(
-        rng: &mut impl CryptoRngCore,
-        bit_length: u32,
-        bits_precision: u32,
-    ) -> Self;
+    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self;
 
     /// Probabilistically checks if the given number is prime using the provided RNG.
     ///
@@ -47,19 +39,11 @@ impl<T> RandomPrimeWithRng for T
 where
     T: Integer + RandomBits + RandomMod,
 {
-    fn generate_prime_with_rng(
-        rng: &mut impl CryptoRngCore,
-        bit_length: u32,
-        bits_precision: u32,
-    ) -> Self {
-        generate_prime_with_rng(rng, bit_length, bits_precision)
+    fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
+        generate_prime_with_rng(rng, bit_length)
     }
-    fn generate_safe_prime_with_rng(
-        rng: &mut impl CryptoRngCore,
-        bit_length: u32,
-        bits_precision: u32,
-    ) -> Self {
-        generate_safe_prime_with_rng(rng, bit_length, bits_precision)
+    fn generate_safe_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
+        generate_safe_prime_with_rng(rng, bit_length)
     }
     fn is_prime_with_rng(&self, rng: &mut impl CryptoRngCore) -> bool {
         is_prime_with_rng(rng, self)
@@ -71,7 +55,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crypto_bigint::U64;
+    use crypto_bigint::{BoxedUint, U64};
     use rand_core::OsRng;
 
     use super::RandomPrimeWithRng;
@@ -84,10 +68,22 @@ mod tests {
         assert!(!U64::from(13u32).is_safe_prime_with_rng(&mut OsRng));
         assert!(U64::from(11u32).is_safe_prime_with_rng(&mut OsRng));
 
+        assert!(U64::generate_prime_with_rng(&mut OsRng, 10).is_prime_with_rng(&mut OsRng));
         assert!(
-            U64::generate_prime_with_rng(&mut OsRng, 10, U64::BITS).is_prime_with_rng(&mut OsRng)
+            U64::generate_safe_prime_with_rng(&mut OsRng, 10).is_safe_prime_with_rng(&mut OsRng)
         );
-        assert!(U64::generate_safe_prime_with_rng(&mut OsRng, 10, U64::BITS)
+    }
+
+    #[test]
+    fn boxed_uint_impl() {
+        assert!(!BoxedUint::from(15u32).is_prime_with_rng(&mut OsRng));
+        assert!(BoxedUint::from(19u32).is_prime_with_rng(&mut OsRng));
+
+        assert!(!BoxedUint::from(13u32).is_safe_prime_with_rng(&mut OsRng));
+        assert!(BoxedUint::from(11u32).is_safe_prime_with_rng(&mut OsRng));
+
+        assert!(BoxedUint::generate_prime_with_rng(&mut OsRng, 10).is_prime_with_rng(&mut OsRng));
+        assert!(BoxedUint::generate_safe_prime_with_rng(&mut OsRng, 10)
             .is_safe_prime_with_rng(&mut OsRng));
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,4 @@
-use crypto_bigint::{Integer, RandomBits, RandomMod};
+use crypto_bigint::{zeroize::Zeroize, Integer, RandomBits, RandomMod};
 use rand_core::CryptoRngCore;
 
 use crate::{
@@ -8,7 +8,7 @@ use crate::{
 
 /// Provides a generic way to access methods for random prime number generation
 /// and primality checking, wrapping the standalone functions ([`is_prime_with_rng`] etc).
-pub trait RandomPrimeWithRng {
+pub trait RandomPrimeWithRng: Zeroize {
     /// Returns a random prime of size `bit_length` using the provided RNG.
     ///
     /// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
@@ -37,7 +37,7 @@ pub trait RandomPrimeWithRng {
 
 impl<T> RandomPrimeWithRng for T
 where
-    T: Integer + RandomBits + RandomMod,
+    T: Integer + RandomBits + RandomMod + Zeroize,
 {
     fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
         generate_prime_with_rng(rng, bit_length)

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,4 @@
-use crypto_bigint::{zeroize::Zeroize, Integer, RandomBits, RandomMod};
+use crypto_bigint::{Integer, RandomBits, RandomMod};
 use rand_core::CryptoRngCore;
 
 use crate::{
@@ -8,7 +8,7 @@ use crate::{
 
 /// Provides a generic way to access methods for random prime number generation
 /// and primality checking, wrapping the standalone functions ([`is_prime_with_rng`] etc).
-pub trait RandomPrimeWithRng: Zeroize {
+pub trait RandomPrimeWithRng {
     /// Returns a random prime of size `bit_length` using the provided RNG.
     ///
     /// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
@@ -37,7 +37,7 @@ pub trait RandomPrimeWithRng: Zeroize {
 
 impl<T> RandomPrimeWithRng for T
 where
-    T: Integer + RandomBits + RandomMod + Zeroize,
+    T: Integer + RandomBits + RandomMod,
 {
     fn generate_prime_with_rng(rng: &mut impl CryptoRngCore, bit_length: u32) -> Self {
         generate_prime_with_rng(rng, bit_length)


### PR DESCRIPTION
An attempt to provide a more ergonomic API that works for both heap and stack allocated uints.

Before we had:

```rust
// `…where T: Integer + RandomBits`
let n = random_odd_integer::<T>(rng, NonZeroU32::new(bit_length).unwrap(), bits_precision);
let p = generate_prime_with_rng::<U1024>(&mut rng, 1024, 1024);
```

With this PR:

```rust
let n = random_odd_integer::<T>(rng, NonZeroU32::new(bit_length).unwrap());
let p = generate_prime_with_rng::<U1024>(&mut rng, 1024);
```

I think this is a more ergonomic public API.

Perhaps more contentiously, this PR also switches to prefer passing numeric parameters by value rather than by reference. 

If reviewers think this makes the PR too noisy to review, I can split out those changes.
