### PR TITLE
Fix overflow when initializing a Sieve with T::MAX

### DIFF
--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -140,14 +140,14 @@ impl<T: Integer> Sieve<T> {
             return false;
         }
 
-        // Set the new base. This increment will not overflow unless the `Sieve` is misused and manipulated.
-        match self.base.checked_add(&self.incr.into()).into() {
-            Some(x) => self.base = x,
-            None => {
-                self.last_round = true;
-                return false;
-            }
-        }
+        // Set the new base.
+        // Should not overflow since `incr` is never greater than `incr_limit`,
+        // and the latter is chosen such that it doesn't overflow when added to `base`
+        // (see the rest of this method).
+        self.base = self
+            .base
+            .checked_add(&self.incr.into())
+            .expect("Does not overflow by construction");
 
         self.incr = 0;
 

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -268,7 +268,7 @@ mod tests {
     use alloc::vec::Vec;
     use core::num::NonZeroU32;
 
-    use crypto_bigint::{U1024, U64};
+    use crypto_bigint::U64;
     use num_prime::nt_funcs::factorize64;
     use rand_chacha::ChaCha8Rng;
     use rand_core::{OsRng, SeedableRng};
@@ -388,14 +388,6 @@ mod tests {
     fn sieve_with_max_start() {
         let start = U64::MAX;
         let mut sieve = Sieve::new(&start, NonZeroU32::new(U64::BITS).unwrap(), false);
-        assert!(sieve.next().is_none());
-    }
-
-    #[test]
-    fn sieve_with_max_start_and_malicious_manipulation() {
-        let start = U1024::MAX;
-        let mut sieve = Sieve::new(&start, NonZeroU32::new(U1024::BITS).unwrap(), false);
-        sieve.incr = 10; // Cause overflow in update_residues()
         assert!(sieve.next().is_none());
     }
 }


### PR DESCRIPTION
Avoids a panic when initializing a `Sieve` with `T::MAX`.
