### PR TITLE
Pin crypto-bigint to rc.2 until rc.6 is out

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,20 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.73"
 
 [dependencies]
-crypto-bigint = { version = "0.6.0-pre.7", default-features = false, features = ["rand_core"] }
+crypto-bigint = { version = "=0.6.0-rc.2", default-features = false, features = [
+	"rand_core",
+] }
 rand_core = { version = "0.6.4", default-features = false }
 openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
-rug = { version = "1.26", default-features = false, features = ["integer"], optional = true }
+rug = { version = "1.26", default-features = false, features = [
+	"integer",
+], optional = true }
 
 [dev-dependencies]
 # need `crypto-bigint` with `alloc` to test `BoxedUint`
-crypto-bigint = { version = "0.6.0-pre.7", default-features = false, features = ["alloc"] }
+crypto-bigint = { version = "=0.6.0-rc.2", default-features = false, features = [
+	"alloc",
+] }
 rand_chacha = "0.3"
 criterion = { version = "0.5", features = ["html_reports"] }
 num-modular = { version = "0.5", features = ["num-bigint"] }

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -189,9 +189,10 @@ fn _is_prime_with_rng<T: Integer + RandomMod>(rng: &mut impl CryptoRngCore, num:
 
 #[cfg(test)]
 mod tests {
-    use crypto_bigint::{BoxedUint, CheckedAdd, Uint, Word, U128, U64};
+    use crypto_bigint::{BoxedUint, CheckedAdd, Uint, Word, U128, U256, U64};
     use num_prime::nt_funcs::is_prime64;
-    use rand_core::OsRng;
+    use rand_chacha::ChaCha8Rng;
+    use rand_core::{OsRng, SeedableRng};
 
     use super::{
         generate_prime, generate_prime_with_rng, generate_safe_prime, generate_safe_prime_with_rng,
@@ -379,6 +380,12 @@ mod tests {
                 assert!(is_prime_ref(p_word) && is_prime_ref(p_word / 2));
             }
         }
+    }
+
+    #[test]
+    fn generate_prime_into_int_double_size_precision() {
+        let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
+        let _p = generate_safe_prime_with_rng::<U256>(&mut rng, 128, 256);
     }
 }
 


### PR DESCRIPTION
Until we can use a fixed version, best pin crypto-bigint to known-good version.
