### PR TITLE
Add cargo-careful to CI

### DIFF
--- a/.github/workflows/crypto-primes.yml
+++ b/.github/workflows/crypto-primes.yml
@@ -150,4 +150,4 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: "cargo-careful"
-      - run: cargo +nightly careful setup && cargo +nightly careful test
+      - run: cargo +nightly careful setup && cargo +nightly careful test --features=tests-exhaustive

--- a/.github/workflows/crypto-primes.yml
+++ b/.github/workflows/crypto-primes.yml
@@ -150,4 +150,4 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: "cargo-careful"
-      - run: cargo careful setup && cargo careful test
+      - run: cargo +nightly careful setup && cargo +nightly careful test

--- a/.github/workflows/crypto-primes.yml
+++ b/.github/workflows/crypto-primes.yml
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           profile: minimal
       - uses: baptiste0928/cargo-install@v3
         with:

--- a/.github/workflows/crypto-primes.yml
+++ b/.github/workflows/crypto-primes.yml
@@ -150,4 +150,4 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: "cargo-careful"
-      - run: cargo careful test
+      - run: cargo careful setup && cargo careful test

--- a/.github/workflows/crypto-primes.yml
+++ b/.github/workflows/crypto-primes.yml
@@ -150,4 +150,4 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: "cargo-careful"
-      - run: cargo-careful test
+      - run: cargo careful test

--- a/.github/workflows/crypto-primes.yml
+++ b/.github/workflows/crypto-primes.yml
@@ -2,10 +2,10 @@ name: crypto-primes
 on:
   workflow_dispatch:
   pull_request:
-    paths-ignore: [ README.md ]
+    paths-ignore: [README.md]
   push:
     branches: master
-    paths-ignore: [ README.md ]
+    paths-ignore: [README.md]
 
 env:
   CARGO_INCREMENTAL: 0
@@ -138,3 +138,16 @@ jobs:
           toolchain: 1.73.0
           profile: minimal
       - run: cargo build --all-features --benches
+
+  cargo-careful:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - uses: baptiste0928/cargo-install@v3
+        with:
+          crate: "cargo-careful"
+      - run: cargo-careful test


### PR DESCRIPTION
`cargo-careful` runs tests "extra carefully" and is a middle ground between just running tests and running miri: it finds more UB than the former, and less than the latter.
