### PR TITLE
Add binary GCD

### DIFF
--- a/src/hazmat/gcd.rs
+++ b/src/hazmat/gcd.rs
@@ -3,7 +3,6 @@ use crypto_bigint::{Integer, Limb, NonZero, Word};
 /// Calculates the greatest common divisor of `n` and `m`.
 /// By definition, `gcd(0, m) == m`.
 /// `n` must be non-zero.
-#[inline]
 pub(crate) fn gcd_vartime<T: Integer>(n: &T, m: NonZero<Word>) -> Word {
     let m = m.get();
     // This we can check since it doesn't affect the return type,
@@ -42,8 +41,7 @@ pub(crate) fn gcd_vartime<T: Integer>(n: &T, m: NonZero<Word>) -> Word {
 // As GCD is commutative `gcd(n, m) = gcd(m, n)` those identities still apply if the operands are swapped.
 //
 // [1]: https://en.wikipedia.org/wiki/Binary_GCD_algorithm
-#[inline(always)]
-fn binary_gcd(mut n: u64, mut m: u64) -> u64 {
+fn binary_gcd(mut n: Word, mut m: Word) -> Word {
     // Using identities 2 and 3:
     // gcd(2ⁱn, 2ʲm) = 2ᵏ gcd(n, m) with n, m odd and k = min(i, j)
     // 2ᵏ is the greatest power of two that divides both 2ⁱn and 2ʲm

--- a/src/hazmat/gcd.rs
+++ b/src/hazmat/gcd.rs
@@ -4,7 +4,7 @@ use crypto_bigint::{Integer, Limb, NonZero, Word};
 /// By definition, `gcd(0, m) == m`.
 /// `n` must be non-zero.
 #[inline]
-pub fn gcd_vartime<T: Integer>(n: &T, m: Word) -> Word {
+pub(crate) fn gcd_vartime<T: Integer>(n: &T, m: Word) -> Word {
     // This is an internal function, and it will never be called with `m = 0`.
     // Allowing `m = 0` would require us to have the return type of `Uint<L>`
     // (since `gcd(n, 0) = n`).

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -1,5 +1,5 @@
 //! Lucas primality test.
-use crypto_bigint::{Integer, Limb, Monty, Odd, Square, Word};
+use crypto_bigint::{Integer, Limb, Monty, NonZero, Odd, Square, Word};
 
 use super::{
     gcd::gcd_vartime,
@@ -334,7 +334,10 @@ pub fn lucas_test<T: Integer>(
     // we check that gcd(n, Q) = 1 anyway - again, since `Q` is small,
     // it does not noticeably affect the performance.
     if abs_q != 1
-        && gcd_vartime(candidate.as_ref(), abs_q) != 1
+        && gcd_vartime(
+            candidate.as_ref(),
+            NonZero::new(abs_q).expect("q is not zero by construction"),
+        ) != 1
         && candidate.as_ref() > &to_integer(abs_q)
     {
         return Primality::Composite;


### PR DESCRIPTION
Adds binary GCD to the final step of our `gcd_vartime`.

The speedup is real but marginal. 

Before:

```
	           fastest       │ slowest       │ median        │ mean          │ samples │ iters    
        Uint<16>   217.1 ns      │ 1.226 µs      │ 245 ns        │ 245.6 ns      │ 79978   │ 2559296
        Uint<32>   327.8 ns      │ 1.004 µs      │ 346.1 ns      │ 346.8 ns      │ 99701   │ 1595216
        Uint<64>   527.8 ns      │ 1.879 µs      │ 553.9 ns      │ 555.6 ns      │ 110265  │ 882120
```

After:


```
		   fastest       │ slowest       │ median        │ mean          │ samples │ iters
        Uint<16>   184.3 ns      │ 842.4 ns      │ 192.7 ns      │ 200.2 ns      │ 93287   │ 2985184
        Uint<32>   271.4 ns      │ 1.41 µs       │ 298.9 ns      │ 299.3 ns      │ 109994  │ 1759904
        Uint<64>   449.7 ns      │ 5.069 µs      │ 494.2 ns      │ 492.8 ns      │ 99620   │ 796960
```

The true goal here was to compare our own gcd implementation to that of `crypto-bigint`. If the two are comparable then we could perhaps get rid of some code. Sadly that is not the case (at all), given our second operand is a `Word` (aka `u64`) I do not think the performance difference is due to any inefficiency we can address easily. The difference is one to two orders of magnitude.
