### PR TITLE
Prepare v0.6.0-pre.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bumped `crypto-bigint` to 0.6.0-rc.6 and MSRV to 1.81. ([#55])
-- Add binary GCD ([#54])
-- Add cargo-careful to CI ([#52])
-- Better formatting (up to 120 char) ([#51])
-- Test a prime with 128 zeroes ([#50])
-- More perf tests ([#49])
+- Switch to binary GCD for improved performance ([#54])
 - Remove bit precision from the public API ([#46])
 
 [#55]: https://github.com/entropyxyz/crypto-primes/pull/55
 [#54]: https://github.com/entropyxyz/crypto-primes/pull/54
-[#52]: https://github.com/entropyxyz/crypto-primes/pull/52
-[#51]: https://github.com/entropyxyz/crypto-primes/pull/51
-[#50]: https://github.com/entropyxyz/crypto-primes/pull/50
-[#49]: https://github.com/entropyxyz/crypto-primes/pull/49
 [#46]: https://github.com/entropyxyz/crypto-primes/pull/46
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,27 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## Unreleased
+
+## [0.6.0-pre.2] - 2024-10-15
 
 ### Changed
 
-- Bumped `crypto-bigint` to 0.6.0-rc.6 (pinned) and MSRV to 1.81. ([#55])
+- Bumped `crypto-bigint` to 0.6.0-rc.6 and MSRV to 1.81. ([#55])
+- Add binary GCD ([#54])
+- Add cargo-careful to CI ([#52])
+- Better formatting (up to 120 char) ([#51])
+- Test a prime with 128 zeroes ([#50])
+- More perf tests ([#49])
 - Remove bit precision from the public API ([#46])
 
 [#55]: https://github.com/entropyxyz/crypto-primes/pull/55
+[#54]: https://github.com/entropyxyz/crypto-primes/pull/54
+[#52]: https://github.com/entropyxyz/crypto-primes/pull/52
+[#51]: https://github.com/entropyxyz/crypto-primes/pull/51
+[#50]: https://github.com/entropyxyz/crypto-primes/pull/50
+[#49]: https://github.com/entropyxyz/crypto-primes/pull/49
 [#46]: https://github.com/entropyxyz/crypto-primes/pull/46
 
 
@@ -18,7 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bumped `crypto-bigint` to 0.6.0-rc.2 (and pinned, since there is a bug introduced in rc.3). ([#48])
+- Bumped `crypto-bigint` to 0.6.0-rc.2 (and pinned, since there is a bug introduced in rc.3).
+  ([#48])
 
 
 [#48]: https://github.com/entropyxyz/crypto-primes/pull/48

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-primes"
-version = "0.6.0-pre.1"
+version = "0.6.0-pre.2"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = "Random prime number generation and primality checking library"
@@ -10,21 +10,15 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.81"
 
 [dependencies]
-crypto-bigint = { version = "=0.6.0-rc.6", default-features = false, features = [
-	"rand_core",
-] }
+crypto-bigint = { version = "0.6.0-rc.6", default-features = false, features = ["rand_core"] }
 rand_core = { version = "0.6.4", default-features = false }
 openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
-rug = { version = "1.26", default-features = false, features = [
-	"integer",
-], optional = true }
+rug = { version = "1.26", default-features = false, features = ["integer"], optional = true }
 glass_pumpkin = { version = "1", optional = true }
 
 [dev-dependencies]
 # need `crypto-bigint` with `alloc` to test `BoxedUint`
-crypto-bigint = { version = "=0.6.0-rc.6", default-features = false, features = [
-	"alloc",
-] }
+crypto-bigint = { version = "0.6.0-rc.6", default-features = false, features = ["alloc"] }
 rand_chacha = "0.3"
 criterion = { version = "0.5", features = ["html_reports"] }
 num-modular = { version = "0.5", features = ["num-bigint"] }
@@ -40,12 +34,7 @@ tests-openssl = ["openssl"]
 tests-gmp = ["rug/std"]
 tests-glass-pumpkin = ["glass_pumpkin"]
 tests-exhaustive = []
-tests-all = [
-	"tests-openssl",
-	"tests-gmp",
-	"tests-exhaustive",
-	"tests-glass-pumpkin",
-]
+tests-all = ["tests-openssl", "tests-gmp", "tests-exhaustive", "tests-glass-pumpkin"]
 
 [package.metadata.docs.rs]
 features = ["default"]


### PR DESCRIPTION
The last published version pins crypto-bigint to rc.2 making it impossible for e.g. synedrion to move on to rc.6, hence this proposal to relax the version requirement and publish a pre.2.
