### PR TITLE
Parallel prime generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+### Added
+- Parallel prime finding methods and a "rayon" feature ([#60])
+
+[#60]: https://github.com/entropyxyz/crypto-primes/pull/60
+
 ## [0.6.0-pre.2] - 2024-10-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- Parallel prime finding methods and a "rayon" feature ([#60])
+- Parallel prime finding methods and a "multicore" feature ([#60])
 
 [#60]: https://github.com/entropyxyz/crypto-primes/pull/60
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ num-bigint = "0.4"
 num-integer = "0.1"
 proptest = "1"
 num-prime = "0.4.3"
+num_cpus = "1.16"
 
 [features]
 default = ["default-rng"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tests-gmp = ["rug/std"]
 tests-glass-pumpkin = ["glass_pumpkin"]
 tests-exhaustive = []
 tests-all = ["tests-openssl", "tests-gmp", "tests-exhaustive", "tests-glass-pumpkin"]
-rayon = ["dep:rayon"]
+multicore = ["rayon"]
 
 [package.metadata.docs.rs]
 features = ["default"]
@@ -51,6 +51,5 @@ name = "bench"
 harness = false
 
 [profile.bench]
-opt-level = 3
 lto = true
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ rand_core = { version = "0.6.4", default-features = false }
 openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
 rug = { version = "1.26", default-features = false, features = ["integer"], optional = true }
 glass_pumpkin = { version = "1", optional = true }
+rayon = { version = "1", optional = true }
+num_cpus = { version = "1", optional = true }
 
 [dev-dependencies]
 # need `crypto-bigint` with `alloc` to test `BoxedUint`
@@ -35,6 +37,7 @@ tests-gmp = ["rug/std"]
 tests-glass-pumpkin = ["glass_pumpkin"]
 tests-exhaustive = []
 tests-all = ["tests-openssl", "tests-gmp", "tests-exhaustive", "tests-glass-pumpkin"]
+rayon = ["dep:rayon", "num_cpus"]
 
 [package.metadata.docs.rs]
 features = ["default"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,12 @@ rust-version = "1.81"
 [dependencies]
 crypto-bigint = { version = "0.6.0-rc.6", default-features = false, features = ["rand_core"] }
 rand_core = { version = "0.6.4", default-features = false }
+
+# Optional dependencies used in tests and benchmarks
 openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
 rug = { version = "1.26", default-features = false, features = ["integer"], optional = true }
 glass_pumpkin = { version = "1", optional = true }
 rayon = { version = "1", optional = true }
-num_cpus = { version = "1", optional = true }
 
 [dev-dependencies]
 # need `crypto-bigint` with `alloc` to test `BoxedUint`
@@ -37,7 +38,7 @@ tests-gmp = ["rug/std"]
 tests-glass-pumpkin = ["glass_pumpkin"]
 tests-exhaustive = []
 tests-all = ["tests-openssl", "tests-gmp", "tests-exhaustive", "tests-glass-pumpkin"]
-rayon = ["dep:rayon", "num_cpus"]
+rayon = ["dep:rayon"]
 
 [package.metadata.docs.rs]
 features = ["default"]
@@ -47,3 +48,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 [[bench]]
 name = "bench"
 harness = false
+
+[profile.bench]
+opt-level = 3
+lto = true
+codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ In particular:
 - Miller-Rabin test;
 - Strong and extra strong Lucas tests, and Lucas-V test.
 
-See the documentation for the specific tests for more information and references.
 
 The library is no-std compatible and contains no unsafe code.
 
@@ -47,7 +46,7 @@ Advanced users can use the [`hazmat`][hazmat-lnk] module in the library to build
 The following features are available:
 
 - `default-rng`: Use the OS default CSPRNG, `OsRng`. Enabled by default.
-- `rayon`: Enables additional parallel prime finding functions. Disabled by default.
+- `multicore`: Enables additional parallel prime finding functions. Disabled by default.
 
 
 [crate-image]: https://img.shields.io/crates/v/crypto-primes.svg
@@ -59,4 +58,4 @@ The following features are available:
 [build-link]: https://github.com/entropyxyz/crypto-primes/actions?query=workflow%3Acrypto-primes
 [coverage-image]: https://codecov.io/gh/entropyxyz/crypto-primes/branch/master/graph/badge.svg
 [coverage-link]: https://codecov.io/gh/entropyxyz/crypto-primes
-[hazmat-lnk]: crate::hazmat
+[hazmat-lnk]: https://docs.rs/crypto-primes/latest/crypto_primes/hazmat

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Find a 196 bit prime returned in a 256-bit long `crypto_bigint::U256`:
 ```rust
 use crypto_bigint::U256;
 let prime = crypto_primes::generate_prime::<U256>(196);
-assert!(crypto_primes::is_prime(prime));
+assert!(crypto_primes::is_prime(&prime));
 ```
 
 Find a 64 bit safe prime returned in a `crypto_bigint::U1024`:
@@ -35,7 +35,7 @@ Find a 64 bit safe prime returned in a `crypto_bigint::U1024`:
 ```rust
 use crypto_bigint::U1024;
 let prime = crypto_primes::generate_safe_prime::<U1024>(64);
-assert!(crypto_primes::is_safe_prime(prime));
+assert!(crypto_primes::is_safe_prime(&prime));
 ```
 
 ## Advanced

--- a/README.md
+++ b/README.md
@@ -16,6 +16,39 @@ In particular:
 
 See the documentation for the specific tests for more information and references.
 
+The library is no-std compatible and contains no unsafe code.
+
+Most users will be using the small set of functions exported from the top level, providing "pre-packaged" prime finding functionality with sane defaults.
+
+## Example
+
+Find a 196 bit prime returned in a 256-bit long `crypto_bigint::U256`:
+
+```rust
+use crypto_bigint::U256;
+let prime = crypto_primes::generate_prime::<U256>(196);
+assert!(crypto_primes::is_prime(prime));
+```
+
+Find a 64 bit safe prime returned in a `crypto_bigint::U1024`:
+
+```rust
+use crypto_bigint::U1024;
+let prime = crypto_primes::generate_safe_prime::<U1024>(64);
+assert!(crypto_primes::is_safe_prime(prime));
+```
+
+## Advanced
+
+Advanced users can use the [`hazmat`][hazmat-lnk] module in the library to build a custom prime finding solution that best fit their needs, e.g. by picking different Lucas bases or running Miller-Rabin tests with particular bases.
+
+## Features
+
+The following features are available:
+
+- `default-rng`: Use the OS default CSPRNG, `OsRng`. Enabled by default.
+- `rayon`: Enables additional parallel prime finding functions. Disabled by default.
+
 
 [crate-image]: https://img.shields.io/crates/v/crypto-primes.svg
 [crate-link]: https://crates.io/crates/crypto-primes
@@ -26,3 +59,4 @@ See the documentation for the specific tests for more information and references
 [build-link]: https://github.com/entropyxyz/crypto-primes/actions?query=workflow%3Acrypto-primes
 [coverage-image]: https://codecov.io/gh/entropyxyz/crypto-primes/branch/master/graph/badge.svg
 [coverage-link]: https://codecov.io/gh/entropyxyz/crypto-primes
+[hazmat-lnk]: crate::hazmat

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -18,7 +18,7 @@ use crypto_primes::{
     },
     is_prime_with_rng, is_safe_prime_with_rng,
 };
-#[cfg(feature = "rayon")]
+#[cfg(feature = "multicore")]
 use crypto_primes::{par_generate_prime_with_rng, par_generate_safe_prime_with_rng};
 
 fn make_rng() -> ChaCha8Rng {
@@ -279,9 +279,9 @@ fn bench_presets(c: &mut Criterion) {
     group.finish();
 }
 
-#[cfg(feature = "rayon")]
-fn bench_rayon_presets(c: &mut Criterion) {
-    let mut group = c.benchmark_group("Presets (rayon)");
+#[cfg(feature = "multicore")]
+fn bench_multicore_presets(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Presets (multicore)");
     let mut rng = make_rng();
     group.bench_function("(U128) Random prime", |b| {
         b.iter(|| par_generate_prime_with_rng::<U128>(&mut rng, 128, num_cpus::get()))
@@ -314,8 +314,8 @@ fn bench_rayon_presets(c: &mut Criterion) {
         b.iter(|| par_generate_safe_prime_with_rng::<BoxedUint>(&mut rng, 1024, num_cpus::get()))
     });
 }
-#[cfg(not(feature = "rayon"))]
-fn bench_rayon_presets(_c: &mut Criterion) {}
+#[cfg(not(feature = "multicore"))]
+fn bench_multicore_presets(_c: &mut Criterion) {}
 
 #[cfg(feature = "tests-gmp")]
 fn bench_gmp(c: &mut Criterion) {
@@ -527,7 +527,7 @@ criterion_group!(
     bench_miller_rabin,
     bench_lucas,
     bench_presets,
-    bench_rayon_presets,
+    bench_multicore_presets,
     bench_gmp,
     bench_openssl,
     bench_glass_pumpkin,

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -18,6 +18,8 @@ use crypto_primes::{
     },
     is_prime_with_rng, is_safe_prime_with_rng,
 };
+#[cfg(feature = "rayon")]
+use crypto_primes::{par_generate_prime_with_rng, par_generate_safe_prime_with_rng};
 
 fn make_rng() -> ChaCha8Rng {
     ChaCha8Rng::from_seed(*b"01234567890123456789012345678901")
@@ -277,6 +279,44 @@ fn bench_presets(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(feature = "rayon")]
+fn bench_rayon_presets(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Presets (rayon)");
+    let mut rng = make_rng();
+    group.bench_function("(U128) Random prime", |b| {
+        b.iter(|| par_generate_prime_with_rng::<U128>(&mut rng, 128, num_cpus::get()))
+    });
+
+    let mut rng = make_rng();
+    group.bench_function("(U1024) Random prime", |b| {
+        b.iter(|| par_generate_prime_with_rng::<U1024>(&mut rng, 1024, num_cpus::get()))
+    });
+
+    let mut rng = make_rng();
+    group.bench_function("(U128) Random safe prime", |b| {
+        b.iter(|| par_generate_safe_prime_with_rng::<U128>(&mut rng, 128, num_cpus::get()))
+    });
+
+    group.sample_size(20);
+    let mut rng = make_rng();
+    group.bench_function("(U1024) Random safe prime", |b| {
+        b.iter(|| par_generate_safe_prime_with_rng::<U1024>(&mut rng, 1024, num_cpus::get()))
+    });
+
+    let mut rng = make_rng();
+    group.bench_function("(Boxed128) Random safe prime", |b| {
+        b.iter(|| par_generate_safe_prime_with_rng::<BoxedUint>(&mut rng, 128, num_cpus::get()))
+    });
+
+    group.sample_size(20);
+    let mut rng = make_rng();
+    group.bench_function("(Boxed1024) Random safe prime", |b| {
+        b.iter(|| par_generate_safe_prime_with_rng::<BoxedUint>(&mut rng, 1024, num_cpus::get()))
+    });
+}
+#[cfg(not(feature = "rayon"))]
+fn bench_rayon_presets(_c: &mut Criterion) {}
+
 #[cfg(feature = "tests-gmp")]
 fn bench_gmp(c: &mut Criterion) {
     let mut group = c.benchmark_group("GMP");
@@ -487,6 +527,7 @@ criterion_group!(
     bench_miller_rabin,
     bench_lucas,
     bench_presets,
+    bench_rayon_presets,
     bench_gmp,
     bench_openssl,
     bench_glass_pumpkin,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ mod traits;
 pub use presets::{generate_prime_with_rng, generate_safe_prime_with_rng, is_prime_with_rng, is_safe_prime_with_rng};
 pub use traits::RandomPrimeWithRng;
 
-#[cfg(feature = "rayon")]
-pub use presets::par_generate_prime_with_rng;
 #[cfg(feature = "default-rng")]
 pub use presets::{generate_prime, generate_safe_prime, is_prime, is_safe_prime};
+#[cfg(feature = "rayon")]
+pub use presets::{par_generate_prime_with_rng, par_generate_safe_prime_with_rng};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,5 +23,7 @@ mod traits;
 pub use presets::{generate_prime_with_rng, generate_safe_prime_with_rng, is_prime_with_rng, is_safe_prime_with_rng};
 pub use traits::RandomPrimeWithRng;
 
+#[cfg(feature = "rayon")]
+pub use presets::par_generate_prime_with_rng;
 #[cfg(feature = "default-rng")]
 pub use presets::{generate_prime, generate_safe_prime, is_prime, is_safe_prime};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub use traits::RandomPrimeWithRng;
 
 #[cfg(feature = "default-rng")]
 pub use presets::{generate_prime, generate_safe_prime, is_prime, is_safe_prime};
-#[cfg(all(feature = "default-rng", feature = "rayon"))]
+#[cfg(all(feature = "default-rng", feature = "multicore"))]
 pub use presets::{par_generate_prime, par_generate_safe_prime};
-#[cfg(feature = "rayon")]
+#[cfg(feature = "multicore")]
 pub use presets::{par_generate_prime_with_rng, par_generate_safe_prime_with_rng};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,5 +25,7 @@ pub use traits::RandomPrimeWithRng;
 
 #[cfg(feature = "default-rng")]
 pub use presets::{generate_prime, generate_safe_prime, is_prime, is_safe_prime};
+#[cfg(all(feature = "default-rng", feature = "rayon"))]
+pub use presets::{par_generate_prime, par_generate_safe_prime};
 #[cfg(feature = "rayon")]
 pub use presets::{par_generate_prime_with_rng, par_generate_safe_prime_with_rng};

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -6,7 +6,7 @@ use rand_core::CryptoRngCore;
 #[cfg(feature = "default-rng")]
 use rand_core::OsRng;
 
-#[cfg(feature = "rayon")]
+#[cfg(feature = "multicore")]
 use rayon::iter::{ParallelBridge, ParallelIterator};
 
 use crate::hazmat::{lucas_test, random_odd_integer, AStarBase, LucasCheck, MillerRabin, Primality, Sieve};
@@ -23,12 +23,12 @@ pub fn generate_prime<T: Integer + RandomBits + RandomMod>(bit_length: u32) -> T
 ///
 /// See [`is_prime_with_rng`] for details about the performed checks.
 ///
-/// Uses [`rayon`] to parallelize the prime search using `corecount/2` threads (but minimum 2).
+/// Uses `threadcount` cores to parallelize the prime search.
 ///
 /// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
 ///
 /// Panics if the platform is unable to spawn threads.
-#[cfg(all(feature = "default-rng", feature = "rayon"))]
+#[cfg(all(feature = "default-rng", feature = "multicore"))]
 pub fn par_generate_prime<T: Integer + RandomBits + RandomMod>(bit_length: u32, threadcount: usize) -> T {
     par_generate_prime_with_rng(&mut OsRng, bit_length, threadcount)
 }
@@ -47,12 +47,12 @@ pub fn generate_safe_prime<T: Integer + RandomBits + RandomMod>(bit_length: u32)
 ///
 /// See [`is_prime_with_rng`] for details about the performed checks.
 ///
-/// Uses [`rayon`] to parallelize the prime search using `corecount/2` threads (but minimum 2).
+/// Uses `threadcount` cores to parallelize the prime search.
 ///
 /// Panics if `bit_length` is less than 3, or greater than the bit size of the target `Uint`.
 ///
 /// Panics if the platform is unable to spawn threads.
-#[cfg(all(feature = "default-rng", feature = "rayon"))]
+#[cfg(all(feature = "default-rng", feature = "multicore"))]
 pub fn par_generate_safe_prime<T: Integer + RandomBits + RandomMod>(bit_length: u32, threadcount: usize) -> T {
     par_generate_safe_prime_with_rng(&mut OsRng, bit_length, threadcount)
 }
@@ -124,12 +124,12 @@ pub fn generate_safe_prime_with_rng<T: Integer + RandomBits + RandomMod>(
 
 /// Returns a random prime of size `bit_length` using the provided RNG.
 ///
-/// Uses [`rayon`] to parallelize the prime search using `corecount/2` threads (but minimum 2).
+/// Uses `threadcount` cores to parallelize the prime search.
 ///
 /// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
 ///
 /// Panics if the platform is unable to spawn threads.
-#[cfg(feature = "rayon")]
+#[cfg(feature = "multicore")]
 pub fn par_generate_prime_with_rng<T>(
     rng: &mut (impl CryptoRngCore + Send + Sync + Clone),
     bit_length: u32,
@@ -168,13 +168,13 @@ where
 /// Returns a random safe prime (that is, such that `(n - 1) / 2` is also prime)
 /// of size `bit_length` using the provided RNG.
 ///
-/// Uses [`rayon`] to parallelize the prime search using `corecount/2` threads (but minimum 2).
+/// Uses `threadcount` cores to parallelize the prime search.
 ///
 /// Panics if `bit_length` is less than 3, or greater than the bit size of the target `Uint`.
 /// Panics if the platform is unable to spawn threads.
 ///
 /// See [`is_prime_with_rng`] for details about the performed checks.
-#[cfg(feature = "rayon")]
+#[cfg(feature = "multicore")]
 pub fn par_generate_safe_prime_with_rng<T>(
     rng: &mut (impl CryptoRngCore + Send + Sync + Clone),
     bit_length: u32,
@@ -487,8 +487,8 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "rayon"))]
-mod rayon_tests {
+#[cfg(all(test, feature = "multicore"))]
+mod multicore_tests {
     use super::{is_prime, par_generate_prime_with_rng};
     use crypto_bigint::{nlimbs, BoxedUint, U128};
 

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -467,7 +467,7 @@ mod rayon_tests {
     #[test]
     fn parallel_prime_generation() {
         for bit_length in (28..=128).step_by(10) {
-            let p: U128 = par_generate_prime_with_rng(&mut OsRng, bit_length);
+            let p: U128 = par_generate_prime_with_rng(&mut OsRng, bit_length, 4);
             assert!(p.bits_vartime() == bit_length);
             assert!(is_prime(&p));
         }
@@ -476,7 +476,7 @@ mod rayon_tests {
     #[test]
     fn parallel_prime_generation_boxed() {
         for bit_length in (28..=128).step_by(10) {
-            let p: BoxedUint = par_generate_prime_with_rng(&mut OsRng, bit_length);
+            let p: BoxedUint = par_generate_prime_with_rng(&mut OsRng, bit_length, 2);
             assert!(p.bits_vartime() == bit_length);
             assert!(p.to_words().len() == nlimbs!(bit_length));
             assert!(is_prime(&p));
@@ -486,7 +486,7 @@ mod rayon_tests {
     #[test]
     fn parallel_safe_prime_generation() {
         for bit_length in (28..=128).step_by(10) {
-            let p: U128 = par_generate_safe_prime_with_rng(&mut OsRng, bit_length);
+            let p: U128 = par_generate_safe_prime_with_rng(&mut OsRng, bit_length, 8);
             assert!(p.bits_vartime() == bit_length);
             assert!(is_prime(&p));
         }
@@ -495,7 +495,7 @@ mod rayon_tests {
     #[test]
     fn parallel_safe_prime_generation_boxed() {
         for bit_length in (28..=128).step_by(10) {
-            let p: BoxedUint = par_generate_safe_prime_with_rng(&mut OsRng, bit_length);
+            let p: BoxedUint = par_generate_safe_prime_with_rng(&mut OsRng, bit_length, 4);
             assert!(p.bits_vartime() == bit_length);
             assert!(p.to_words().len() == nlimbs!(bit_length));
             assert!(is_prime(&p));

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -1,4 +1,4 @@
-use core::num::NonZeroU32;
+use core::num::NonZero;
 
 use crypto_bigint::{Integer, Limb, Odd, RandomBits, RandomMod};
 use rand_core::CryptoRngCore;
@@ -86,7 +86,7 @@ pub fn generate_prime_with_rng<T: Integer + RandomBits + RandomMod>(
     if bit_length < 2 {
         panic!("`bit_length` must be 2 or greater.");
     }
-    let bit_length = NonZeroU32::new(bit_length).expect("`bit_length` should be non-zero");
+    let bit_length = NonZero::new(bit_length).expect("`bit_length` should be non-zero");
     // Empirically, this loop is traversed 1 time.
     loop {
         let start = random_odd_integer::<T>(rng, bit_length);
@@ -110,7 +110,7 @@ pub fn generate_safe_prime_with_rng<T: Integer + RandomBits + RandomMod>(
     if bit_length < 3 {
         panic!("`bit_length` must be 3 or greater.");
     }
-    let bit_length = NonZeroU32::new(bit_length).expect("`bit_length` should be non-zero");
+    let bit_length = NonZero::new(bit_length).expect("`bit_length` should be non-zero");
     loop {
         let start = random_odd_integer::<T>(rng, bit_length);
         let sieve = Sieve::new(start.get(), bit_length, true);
@@ -141,7 +141,7 @@ where
     if bit_length < 2 {
         panic!("`bit_length` must be 2 or greater.");
     }
-    let bit_length = NonZeroU32::new(bit_length).expect("`bit_length` should be non-zero");
+    let bit_length = NonZero::new(bit_length).expect("`bit_length` should be non-zero");
 
     let threadpool = rayon::ThreadPoolBuilder::new()
         .num_threads(threadcount)
@@ -186,7 +186,7 @@ where
     if bit_length < 2 {
         panic!("`bit_length` must be 2 or greater.");
     }
-    let bit_length = NonZeroU32::new(bit_length).expect("`bit_length` should be non-zero");
+    let bit_length = NonZero::new(bit_length).expect("`bit_length` should be non-zero");
 
     let threadpool = rayon::ThreadPoolBuilder::new()
         .num_threads(threadcount)
@@ -536,7 +536,7 @@ mod multicore_tests {
 #[cfg(feature = "tests-openssl")]
 mod tests_openssl {
     use alloc::format;
-    use core::num::NonZeroU32;
+    use core::num::NonZero;
 
     use crypto_bigint::U128;
     use openssl::bn::{BigNum, BigNumContext};
@@ -578,7 +578,7 @@ mod tests_openssl {
 
         // Generate random numbers, check if our test agrees with OpenSSL
         for _ in 0..100 {
-            let p = random_odd_integer::<U128>(&mut OsRng, NonZeroU32::new(128).unwrap());
+            let p = random_odd_integer::<U128>(&mut OsRng, NonZero::new(128).unwrap());
             let actual = is_prime(p.as_ref());
             let p_bn = to_openssl(&p);
             let expected = openssl_is_prime(&p_bn, &mut ctx);
@@ -593,7 +593,7 @@ mod tests_openssl {
 #[cfg(test)]
 #[cfg(feature = "tests-gmp")]
 mod tests_gmp {
-    use core::num::NonZeroU32;
+    use core::num::NonZero;
 
     use crypto_bigint::U128;
     use rand_core::OsRng;
@@ -628,7 +628,7 @@ mod tests_gmp {
 
         // Generate primes with GMP, check them
         for _ in 0..100 {
-            let start = random_odd_integer::<U128>(&mut OsRng, NonZeroU32::new(128).unwrap());
+            let start = random_odd_integer::<U128>(&mut OsRng, NonZero::new(128).unwrap());
             let start_bn = to_gmp(&start);
             let p_bn = start_bn.next_prime();
             let p = from_gmp(&p_bn);
@@ -637,7 +637,7 @@ mod tests_gmp {
 
         // Generate random numbers, check if our test agrees with GMP
         for _ in 0..100 {
-            let p = random_odd_integer::<U128>(&mut OsRng, NonZeroU32::new(128).unwrap());
+            let p = random_odd_integer::<U128>(&mut OsRng, NonZero::new(128).unwrap());
             let actual = is_prime(p.as_ref());
             let p_bn = to_gmp(&p);
             let expected = gmp_is_prime(&p_bn);

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -19,6 +19,20 @@ pub fn generate_prime<T: Integer + RandomBits + RandomMod>(bit_length: u32) -> T
     generate_prime_with_rng(&mut OsRng, bit_length)
 }
 
+/// Returns a random prime of size `bit_length` using [`OsRng`] as the RNG.
+///
+/// See [`is_prime_with_rng`] for details about the performed checks.
+///
+/// Uses [`rayon`] to parallelize the prime search using `corecount/2` threads (but minimum 2).
+///
+/// Panics if `bit_length` is less than 2, or greater than the bit size of the target `Uint`.
+///
+/// Panics if the platform is unable to spawn threads.
+#[cfg(all(feature = "default-rng", feature = "rayon"))]
+pub fn par_generate_prime<T: Integer + RandomBits + RandomMod>(bit_length: u32, threadcount: usize) -> T {
+    par_generate_prime_with_rng(&mut OsRng, bit_length, threadcount)
+}
+
 /// Returns a random safe prime (that is, such that `(n - 1) / 2` is also prime) of size
 /// `bit_length` using [`OsRng`] as the RNG.
 ///
@@ -26,6 +40,21 @@ pub fn generate_prime<T: Integer + RandomBits + RandomMod>(bit_length: u32) -> T
 #[cfg(feature = "default-rng")]
 pub fn generate_safe_prime<T: Integer + RandomBits + RandomMod>(bit_length: u32) -> T {
     generate_safe_prime_with_rng(&mut OsRng, bit_length)
+}
+
+/// Returns a random safe prime (that is, such that `(n - 1) / 2` is also prime) of size
+/// `bit_length` using [`OsRng`] as the RNG.
+///
+/// See [`is_prime_with_rng`] for details about the performed checks.
+///
+/// Uses [`rayon`] to parallelize the prime search using `corecount/2` threads (but minimum 2).
+///
+/// Panics if `bit_length` is less than 3, or greater than the bit size of the target `Uint`.
+///
+/// Panics if the platform is unable to spawn threads.
+#[cfg(all(feature = "default-rng", feature = "rayon"))]
+pub fn par_generate_safe_prime<T: Integer + RandomBits + RandomMod>(bit_length: u32, threadcount: usize) -> T {
+    par_generate_safe_prime_with_rng(&mut OsRng, bit_length, threadcount)
 }
 
 /// Probabilistically checks if the given number is prime using [`OsRng`] as the RNG.

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -101,7 +101,11 @@ pub fn generate_safe_prime_with_rng<T: Integer + RandomBits + RandomMod>(
 ///
 /// Panics if the platform is unable to spawn threads.
 #[cfg(feature = "rayon")]
-pub fn par_generate_prime_with_rng<T>(rng: &mut (impl CryptoRngCore + Send + Sync + Clone), bit_length: u32) -> T
+pub fn par_generate_prime_with_rng<T>(
+    rng: &mut (impl CryptoRngCore + Send + Sync + Clone),
+    bit_length: u32,
+    threadcount: usize,
+) -> T
 where
     T: Integer + RandomBits + RandomMod,
 {
@@ -110,8 +114,6 @@ where
     }
     let bit_length = NonZeroU32::new(bit_length).expect("`bit_length` should be non-zero");
 
-    // TODO(dp): decide how to set the threadcount.
-    let threadcount = core::cmp::max(2, num_cpus::get() / 2);
     let threadpool = rayon::ThreadPoolBuilder::new()
         .num_threads(threadcount)
         .build()
@@ -129,7 +131,7 @@ where
         Some(prime) => prime,
         None => {
             drop(threadpool);
-            par_generate_prime_with_rng(rng, bit_length.get())
+            par_generate_prime_with_rng(rng, bit_length.get(), threadcount)
         }
     }
 }
@@ -144,7 +146,11 @@ where
 ///
 /// See [`is_prime_with_rng`] for details about the performed checks.
 #[cfg(feature = "rayon")]
-pub fn par_generate_safe_prime_with_rng<T>(rng: &mut (impl CryptoRngCore + Send + Sync + Clone), bit_length: u32) -> T
+pub fn par_generate_safe_prime_with_rng<T>(
+    rng: &mut (impl CryptoRngCore + Send + Sync + Clone),
+    bit_length: u32,
+    threadcount: usize,
+) -> T
 where
     T: Integer + RandomBits + RandomMod,
 {
@@ -153,8 +159,6 @@ where
     }
     let bit_length = NonZeroU32::new(bit_length).expect("`bit_length` should be non-zero");
 
-    // TODO(dp): decide how to set the threadcount.
-    let threadcount = core::cmp::max(2, num_cpus::get() / 2);
     let threadpool = rayon::ThreadPoolBuilder::new()
         .num_threads(threadcount)
         .build()
@@ -172,7 +176,7 @@ where
         Some(prime) => prime,
         None => {
             drop(threadpool);
-            par_generate_safe_prime_with_rng(rng, bit_length.get())
+            par_generate_safe_prime_with_rng(rng, bit_length.get(), threadcount)
         }
     }
 }

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -126,7 +126,7 @@ where
             is_prime_with_rng(&mut rng, c)
         }) {
             // TODO(dp): This clone is very annoying.
-            Some(p) => return p.clone(),
+            Some(p) => p.clone(),
             None => par_generate_prime_with_rng(rng, bit_length.get()),
         }
     })


### PR DESCRIPTION
This adds a new function to the public API, named "par_generate_prime_with_rng", that parallelizes the search for primes.


Outstanding tasks:

- [x] Add the corresponding "par_generate_safe_prime_with_rng"
- [x] ~~Pick the number of threads to use~~
- [x] Decide is it is useful for end users to be able to set the number of threads or not (and if yes, what the API for the should be: generics? another function arg? Env variable?) (7491a06939d96d1e77f9a352bd51fe86f19183b8 adds another function arg)
- [ ] Consider a name change (deferred to #62)
- [x] More and better tests
- [x] `CHANGELOG` entry and better docs
- [x] Write criterion benchmarks

### Results

During this work I have tried out several different parallel implementations, using `rayon` and `chili`. The latter is a new take on low-overhead parallelism and is attractive for its small code size and advertised performance, but in my tests I have not seen good performance from it (see below).

When searching for random primes we do not know how many iterations it will take, only that we will eventually find one. This is reflected in the benchmark results as a big variability, as seen in the "fastest" and "slowest" columns below.

Unsurprisingly, the larger the prime we're looking for, the more we benefit from parallelizing the work. For `Uint<64>`s (aka `U4096`), using 8 CPUs is 6x faster; for `Uint<16>` the speedup is more like 3x.

The benchmarks use the `divan` benchmarking library and ran on a MacBook Pro M3 Max, using 8 threads. The table compares different implementations and sizes. The implementation in this PR is labeled "rayon_find_any2":

```
benches                    fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ benches                               │               │               │               │         │
   ├─ pargen                             │               │               │               │         │
   │  ├─ chili_join2                     │               │               │               │         │
   │  │  ├─ Uint<16>       3.248 ms      │ 54.54 ms      │ 11.3 ms       │ 13.97 ms      │ 250     │ 250
   │  │  ├─ Uint<32>       24.23 ms      │ 3.385 s       │ 124.6 ms      │ 189.2 ms      │ 250     │ 250
   │  │  ╰─ Uint<64>       209.8 ms      │ 33.87 s       │ 1.622 s       │ 2.737 s       │ 250     │ 250
   │  ├─ rayon_find_any                  │               │               │               │         │
   │  │  ├─ Uint<16>       2.885 ms      │ 17.25 ms      │ 5.252 ms      │ 5.946 ms      │ 250     │ 250
   │  │  ├─ Uint<32>       20.37 ms      │ 270.7 ms      │ 41.78 ms      │ 56.22 ms      │ 250     │ 250
   │  │  ╰─ Uint<64>       156.7 ms      │ 3.187 s       │ 558.3 ms      │ 683.7 ms      │ 250     │ 250
   │  ├─ rayon_find_any2 <–– THIS PR     │               │               │               │         │ 
   │  │  ├─ Uint<16>       2.825 ms      │ 14.61 ms      │ 5.367 ms      │ 5.742 ms      │ 250     │ 250
   │  │  ├─ Uint<32>       20.23 ms      │ 175.4 ms      │ 46.5 ms       │ 56.24 ms      │ 250     │ 250
   │  │  ╰─ Uint<64>       156.6 ms      │ 2.749 s       │ 523 ms        │ 703.5 ms      │ 250     │ 250
   │  ├─ rayon_join                      │               │               │               │         │
   │  │  ├─ Uint<16>       4.125 ms      │ 16.74 ms      │ 5.569 ms      │ 6.353 ms      │ 250     │ 250
   │  │  ├─ Uint<32>       30.1 ms       │ 256.4 ms      │ 41.14 ms      │ 55.48 ms      │ 250     │ 250
   │  │  ╰─ Uint<64>       233.8 ms      │ 3.044 s       │ 608.6 ms      │ 693.1 ms      │ 250     │ 250
   │  ╰─ single  <–– MASTER              │               │               │               │         │
   │     ├─ Uint<16>       2.276 ms      │ 91.08 ms      │ 14.47 ms      │ 18.83 ms      │ 250     │ 250
   │     ├─ Uint<32>       17.33 ms      │ 1.277 s       │ 180.3 ms      │ 256.4 ms      │ 250     │ 250
   │     ╰─ Uint<64>       156.2 ms      │ 18.13 s       │ 3.005 s       │ 4.071 s       │ 250     │ 250
```

There is likely ways to do better than what is presented here, but this is a library and not a prime searching application and there's a value in keeping things simple&nimble. A more efficient parallelizing solution would probably use more code to synchronize threads (channels or shared memory); indeed the reason why `chili` is slower than `rayon` here is because the latter has more facilities in place to halt jobs when a prime is found.

