### PR TITLE
Allow custom MSB setting in generated primes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `Sieve` to `SmallPrimesSieve`. ([#64])
 - Bumped `crypto-bigint` to 0.6.0-rc.7 and MSRV to 1.83. ([#67])
 - Bumped `crypto-bigint` to 0.6. ([#68])
+- `random_odd_integer()` takes an additional `SetBits` argument. ([#69])
+- `random_odd_integer()` now returns a `Result` instead of panicking. ([#69])
 
 
 ### Added
@@ -23,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#64]: https://github.com/entropyxyz/crypto-primes/pull/64
 [#67]: https://github.com/entropyxyz/crypto-primes/pull/67
 [#68]: https://github.com/entropyxyz/crypto-primes/pull/68
+[#69]: https://github.com/entropyxyz/crypto-primes/pull/69
 
 
 ## [0.6.0-pre.2] - 2024-10-18

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -17,7 +17,7 @@ use rand_core::RngCore;
 use crypto_primes::{
     generate_prime_with_rng, generate_safe_prime_with_rng,
     hazmat::{
-        lucas_test, random_odd_integer, AStarBase, BruteForceBase, LucasCheck, MillerRabin, SelfridgeBase,
+        lucas_test, random_odd_integer, AStarBase, BruteForceBase, LucasCheck, MillerRabin, SelfridgeBase, SetBits,
         SmallPrimesSieve,
     },
     is_prime_with_rng, is_safe_prime_with_rng,
@@ -37,7 +37,7 @@ fn make_random_rng() -> ChaCha8Rng {
 }
 
 fn random_odd_uint<T: RandomBits + Integer>(rng: &mut impl CryptoRngCore, bit_length: u32) -> Odd<T> {
-    random_odd_integer::<T>(rng, NonZero::new(bit_length).unwrap())
+    random_odd_integer::<T>(rng, NonZero::new(bit_length).unwrap(), SetBits::Msb).unwrap()
 }
 
 fn make_sieve<const L: usize>(rng: &mut impl CryptoRngCore) -> SmallPrimesSieve<Uint<L>> {
@@ -449,7 +449,9 @@ fn bench_glass_pumpkin(c: &mut Criterion) {
     // Mimics the sequence of checks `glass-pumpkin` does to find a prime.
     fn prime_like_gp(bit_length: u32, rng: &mut impl CryptoRngCore) -> BoxedUint {
         loop {
-            let start = random_odd_integer::<BoxedUint>(rng, NonZero::new(bit_length).unwrap()).get();
+            let start = random_odd_integer::<BoxedUint>(rng, NonZero::new(bit_length).unwrap(), SetBits::Msb)
+                .unwrap()
+                .get();
             let sieve = SmallPrimesSieve::new(start, NonZero::new(bit_length).unwrap(), false);
             for num in sieve {
                 let odd_num = Odd::new(num.clone()).unwrap();
@@ -473,7 +475,9 @@ fn bench_glass_pumpkin(c: &mut Criterion) {
     // Mimics the sequence of checks `glass-pumpkin` does to find a safe prime.
     fn safe_prime_like_gp(bit_length: u32, rng: &mut impl CryptoRngCore) -> BoxedUint {
         loop {
-            let start = random_odd_integer::<BoxedUint>(rng, NonZero::new(bit_length).unwrap()).get();
+            let start = random_odd_integer::<BoxedUint>(rng, NonZero::new(bit_length).unwrap(), SetBits::Msb)
+                .unwrap()
+                .get();
             let sieve = SmallPrimesSieve::new(start, NonZero::new(bit_length).unwrap(), true);
             for num in sieve {
                 let odd_num = Odd::new(num.clone()).unwrap();

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -14,7 +14,7 @@ mod sieve;
 
 pub use lucas::{lucas_test, AStarBase, BruteForceBase, LucasBase, LucasCheck, SelfridgeBase};
 pub use miller_rabin::MillerRabin;
-pub use sieve::{random_odd_integer, SmallPrimesSieve, SmallPrimesSieveFactory};
+pub use sieve::{random_odd_integer, SetBits, SmallPrimesSieve, SmallPrimesSieveFactory};
 
 /// Possible results of various primality tests.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -147,7 +147,7 @@ mod tests {
     use num_prime::nt_funcs::is_prime64;
 
     use super::MillerRabin;
-    use crate::hazmat::{primes, pseudoprimes, random_odd_integer, SmallPrimesSieve};
+    use crate::hazmat::{primes, pseudoprimes, random_odd_integer, SetBits, SmallPrimesSieve};
 
     #[test]
     fn miller_rabin_derived_traits() {
@@ -196,7 +196,7 @@ mod tests {
     #[test]
     fn trivial() {
         let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
-        let start = random_odd_integer::<U1024>(&mut rng, NonZero::new(1024).unwrap());
+        let start = random_odd_integer::<U1024>(&mut rng, NonZero::new(1024).unwrap(), SetBits::Msb).unwrap();
         for num in SmallPrimesSieve::new(start.get(), NonZero::new(1024).unwrap(), false).take(10) {
             let mr = MillerRabin::new(Odd::new(num).unwrap());
 


### PR DESCRIPTION
In the RSA application one needs two primes which, when multiplied, produce a number with a fixed bit length. This can be achieved by requiring two most significant bits to be set on each. The current code just sets the MSB by default, and setting the second one requires writing a custom wrapper over `SmallPrimesSieveFactory`.

This PR attempts to provide a simpler pathway for most common bit-setting cases: no bits set (primes generated up to the chosen bit length), MSB set, and two MSBs set. `random_odd_uint()` and `SmallPrimesSieveFactory` constructors get an additional `SetBits` parameter.

An RSA application would have to use the new functionality by calling 
```rust
    sieve_and_find(
        rng,
        SmallPrimesSieveFactory::new(bit_length, SetBits::TwoMsb),
        is_prime_with_rng,
    )
```

The default currently remains `SetBits::Msb`, but perhaps it should be changed to `SetBits::None`. 