### PR TITLE
Add vector tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.83.0 # MSRV
+          - 1.85.0 # MSRV
           - stable
         target:
           - wasm32-unknown-unknown
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.83.0 # MSRV
+          toolchain: 1.85.0 # MSRV
           components: clippy
           override: true
           profile: minimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introudced `Error` enum; `hazmat` functions and method now return it instead of panicking. ([#79])
 - Renamed `SmallPrimesSieveFactory` to `SmallFactorsSieveFactory`. ([#79])
 - Moved `fips_is_prime()` to its own `fips` submodule and renamed to `is_prime`. ([#79])
+- Bumped `crypto-bigint` to 0.7.0-pre.1 and MSRV to 1.85. ([#80])
 
 
 ### Added
@@ -33,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#70]: https://github.com/entropyxyz/crypto-primes/pull/72
 [#72]: https://github.com/entropyxyz/crypto-primes/pull/72
 [#79]: https://github.com/entropyxyz/crypto-primes/pull/79
+[#80]: https://github.com/entropyxyz/crypto-primes/pull/80
 
 
 ## [0.7.0-pre.0] - 2025-02-22

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.83"
 
 [dependencies]
-crypto-bigint = { version = "0.7.0-pre.0", default-features = false, features = ["rand_core"] }
+crypto-bigint = { version = "0.7.0-pre.1", default-features = false, features = ["rand_core"] }
 rand_core = { version = "0.9.2", default-features = false }
 rayon = { version = "1", optional = true, default-features = false }
 
@@ -22,7 +22,7 @@ glass_pumpkin = { version = "1", optional = true }
 [dev-dependencies]
 rand_core = { version = "0.9.2", default-features = false, features = ["os_rng"] }
 # need `crypto-bigint` with `alloc` to test `BoxedUint`
-crypto-bigint = { version = "0.7.0-pre.0", default-features = false, features = ["alloc"] }
+crypto-bigint = { version = "0.7.0-pre.1", default-features = false, features = ["alloc"] }
 rand_chacha = "0.9"
 criterion = { version = "0.5", features = ["html_reports"] }
 num-modular = { version = "0.5", features = ["num-bigint"] }

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -400,7 +400,7 @@ mod tests {
     use alloc::vec::Vec;
     use core::num::NonZero;
 
-    use crypto_bigint::U64;
+    use crypto_bigint::{U256, U64};
     use num_prime::nt_funcs::factorize64;
     use rand_chacha::ChaCha8Rng;
     use rand_core::{OsRng, SeedableRng, TryRngCore};
@@ -613,5 +613,26 @@ mod tests {
             .unwrap()
             .get();
         assert_eq!(x, U64::ONE);
+    }
+
+    #[test]
+    fn platform_independence() {
+        let mut rng = ChaCha8Rng::from_seed([7u8; 32]);
+
+        let x = random_odd_integer::<U256, _>(&mut rng, NonZero::new(200).unwrap(), SetBits::TwoMsb)
+            .unwrap()
+            .get();
+        assert_eq!(
+            x,
+            U256::from_be_hex("00000000000000E94A74F9D90C0982D7D4F5378BDA8143E6391EBC3F59CBD0E5")
+        );
+
+        let x = random_odd_integer::<U256, _>(&mut rng, NonZero::new(220).unwrap(), SetBits::TwoMsb)
+            .unwrap()
+            .get();
+        assert_eq!(
+            x,
+            U256::from_be_hex("000000000E28CE6059E357411C67F6539AEF56F2B4653F0583D6A2195A9897BB")
+        );
     }
 }


### PR DESCRIPTION
Fixes #25, and checks for 32/64 bit platform dependencies

Also bumping crypto-bigint to 0.7.0-pre.1, and MSRV to 1.85 to match crypto-bigint.