### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
           override: true
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Test in release
+        run: cargo test --features multicore --benches --workspace --release
       - name: Generate code coverage
         run: cargo llvm-cov --features multicore --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,3 +130,18 @@ jobs:
         with:
           crate: "cargo-careful"
       - run: cargo +nightly careful setup && cargo +nightly careful test --features=tests-exhaustive
+
+  semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          profile: minimal
+          override: true
+      - uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: crypto-primes
+          feature-group: all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,18 @@ jobs:
           override: true
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
 
+  # Mimics the setup of docs.rs, but fails on warnings
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          profile: minimal
+      - run: env RUSTDOCFLAGS='--cfg docsrs -D warnings' cargo doc --all-features
+
   test-and-coverage:
     runs-on: ubuntu-latest
     steps:

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -37,8 +37,7 @@ pub trait LucasBase {
 /// Try `D = 1 - 4Q = 5, -7, 9, -11, 13, ...` until `Jacobi(D, n) = -1`.
 /// Return `P = 1, Q = (1 - D) / 4)`.
 ///
-/// [^Baillie1980]:
-///   R. Baillie, S. S. Wagstaff, "Lucas pseudoprimes",
+/// [^Baillie1980]: R. Baillie, S. S. Wagstaff, "Lucas pseudoprimes",
 ///   Math. Comp. 35 1391-1417 (1980),
 ///   DOI: [10.2307/2006406](https://dx.doi.org/10.2307/2006406),
 ///   <http://mpqs.free.fr/LucasPseudoprimes.pdf>
@@ -102,8 +101,7 @@ impl LucasBase for SelfridgeBase {
 ///
 /// Same as [`SelfridgeBase`], but returns `(P = 5, Q = 5)` if the Selfridge base set `Q = -1`.
 ///
-/// [^Baillie1980]:
-///   R. Baillie, S. S. Wagstaff, "Lucas pseudoprimes",
+/// [^Baillie1980]: R. Baillie, S. S. Wagstaff, "Lucas pseudoprimes",
 ///   Math. Comp. 35 1391-1417 (1980),
 ///   DOI: [10.2307/2006406](https://dx.doi.org/10.2307/2006406),
 ///   <http://mpqs.free.fr/LucasPseudoprimes.pdf>
@@ -127,8 +125,7 @@ impl LucasBase for AStarBase {
 /// Try `P = 3, 4, 5, ...` until `Jacobi(D, n) = -1`, where `D = P^2 - 4Q`.
 /// Returns the found `P`, and `Q = 1`.
 ///
-/// [^Baillie]:
-///   R. Baillie, Mathematica code for extra strong Lucas pseudoprimes,
+/// [^Baillie]: R. Baillie, Mathematica code for extra strong Lucas pseudoprimes,
 ///   <https://oeis.org/A217719/a217719.txt>
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct BruteForceBase;
@@ -218,8 +215,7 @@ pub enum LucasCheck {
     ///
     /// If the base is [`SelfridgeBase`], known false positives constitute OEIS:A217120[^A217120].
     ///
-    /// [^Baillie1980]:
-    ///   R. Baillie, S. S. Wagstaff, "Lucas pseudoprimes",
+    /// [^Baillie1980]: R. Baillie, S. S. Wagstaff, "Lucas pseudoprimes",
     ///   Math. Comp. 35 1391-1417 (1980),
     ///   DOI: [10.2307/2006406](https://dx.doi.org/10.2307/2006406),
     ///   <http://mpqs.free.fr/LucasPseudoprimes.pdf>
@@ -238,8 +234,7 @@ pub enum LucasCheck {
     ///
     /// If the base is [`SelfridgeBase`], known false positives constitute OEIS:A217255[^A217255].
     ///
-    /// [^Baillie1980]:
-    ///   R. Baillie, S. S. Wagstaff, "Lucas pseudoprimes",
+    /// [^Baillie1980]: R. Baillie, S. S. Wagstaff, "Lucas pseudoprimes",
     ///   Math. Comp. 35 1391-1417 (1980),
     ///   DOI: [10.2307/2006406](https://dx.doi.org/10.2307/2006406),
     ///   <http://mpqs.free.fr/LucasPseudoprimes.pdf>
@@ -263,8 +258,7 @@ pub enum LucasCheck {
     /// Note: this option is intended for testing against known pseudoprimes;
     /// do not use unless you know what you are doing.
     ///
-    /// [^Jacobsen]:
-    ///   D. Jacobsen, "Pseudoprime Statistics, Tables, and Data",
+    /// [^Jacobsen]: D. Jacobsen, "Pseudoprime Statistics, Tables, and Data",
     ///   <http://ntheory.org/pseudoprimes.html>
     AlmostExtraStrong,
 
@@ -279,13 +273,11 @@ pub enum LucasCheck {
     ///
     /// If the base is [`BruteForceBase`], known false positives constitute OEIS:A217719[^A217719].
     ///
-    /// [^Mo1993]:
-    ///   Zhaiyu Mo, "Diophantine equations, Lucas sequences and pseudoprimes",
+    /// [^Mo1993]: Zhaiyu Mo, "Diophantine equations, Lucas sequences and pseudoprimes",
     ///   graduate thesis, University of Calgary, Calgary, AB (1993)
     ///   DOI: [10.11575/PRISM/10820](https://dx.doi.org/10.11575/PRISM/10820)
     ///
-    /// [^Grantham2001]:
-    ///   J. Grantham, "Frobenius pseudoprimes",
+    /// [^Grantham2001]: J. Grantham, "Frobenius pseudoprimes",
     ///   Math. Comp. 70 873-891 (2001),
     ///   DOI: [10.1090/S0025-5718-00-01197-2](https://dx.doi.org/10.1090/S0025-5718-00-01197-2)
     ///

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -15,10 +15,10 @@ use super::{
 ///
 /// The implementation satisfies the FIPS.186-5 standard[^FIPS].
 ///
-/// [^Pomerance1980]:
-///   C. Pomerance, J. L. Selfridge, S. S. Wagstaff "The Pseudoprimes to 25*10^9",
+/// [^Pomerance1980]: C. Pomerance, J. L. Selfridge, S. S. Wagstaff "The Pseudoprimes to 25*10^9",
 ///   Math. Comp. 35 1003-1026 (1980),
 ///   DOI: [10.2307/2006210](https://dx.doi.org/10.2307/2006210)
+///
 /// [^FIPS]: FIPS-186.5 standard, <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf>
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MillerRabin<T: Integer> {


### PR DESCRIPTION
- Run a benchmark test (`cargo test --benches` runs the benchmarks once to make sure the code inside is actually operational)
- Add a doc building step
- Add a semver check step

Also the doc building step uncovered some errors in the doc syntax, which in turn uncovered that `rustdoc` changed the footnote processing logic at some point between crypto-primes 0.4 and 0.5. Namely, in order to be rendered properly, footnotes cannot start with a line break. That is, this won't render correctly:
```
/// [^Baillie1980]:
///   R. Baillie, S. S. Wagstaff, "Lucas pseudoprimes",
```
but this will:
```
/// [^Baillie1980]: R. Baillie, S. S. Wagstaff, "Lucas pseudoprimes",
```