### PR TITLE
Use `crypto_bigint::Unsigned` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ glass_pumpkin = { version = "1", optional = true }
 [dev-dependencies]
 rand_core = { version = "0.9.2", default-features = false, features = ["os_rng"] }
 # need `crypto-bigint` with `alloc` to test `BoxedUint`
-crypto-bigint = { version = "0.7.0-pre.4", default-features = false, features = ["alloc"] }
+crypto-bigint = { version = "0.7.0-pre.5", default-features = false, features = ["alloc"] }
 rand_chacha = "0.9"
 criterion = { version = "0.5", features = ["html_reports"] }
 num-modular = { version = "0.5", features = ["num-bigint"] }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,7 +1,7 @@
 use core::num::NonZero;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use crypto_bigint::{BoxedUint, Integer, Odd, RandomBits, U128, U256, U1024, Uint, nlimbs};
+use crypto_bigint::{BoxedUint, Odd, RandomBits, U128, U256, U1024, Uint, Unsigned, nlimbs};
 use rand_chacha::ChaCha8Rng;
 use rand_core::{CryptoRng, OsRng, SeedableRng, TryRngCore};
 
@@ -32,7 +32,7 @@ fn make_random_rng() -> ChaCha8Rng {
     ChaCha8Rng::from_os_rng()
 }
 
-fn random_odd_uint<T: RandomBits + Integer, R: CryptoRng + ?Sized>(rng: &mut R, bit_length: u32) -> Odd<T> {
+fn random_odd_uint<T: RandomBits + Unsigned, R: CryptoRng + ?Sized>(rng: &mut R, bit_length: u32) -> Odd<T> {
     random_odd_integer::<T, _>(rng, NonZero::new(bit_length).unwrap(), SetBits::Msb).unwrap()
 }
 

--- a/src/fips.rs
+++ b/src/fips.rs
@@ -2,7 +2,7 @@
 //!
 //! [^FIPS]: FIPS-186.5 standard, <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf>
 
-use crypto_bigint::{Integer, Odd, RandomMod};
+use crypto_bigint::{Odd, RandomMod, Unsigned};
 use rand_core::CryptoRng;
 
 use crate::{
@@ -30,7 +30,7 @@ pub fn is_prime<T>(
     add_lucas_test: bool,
 ) -> bool
 where
-    T: Integer + RandomMod,
+    T: Unsigned + RandomMod,
 {
     match flavor {
         Flavor::Any => {}
@@ -84,7 +84,7 @@ fn is_safe_prime<T>(
     add_lucas_test: bool,
 ) -> bool
 where
-    T: Integer + RandomMod,
+    T: Unsigned + RandomMod,
 {
     // Since, by the definition of safe prime, `(candidate - 1) / 2` must also be prime,
     // and therefore odd, `candidate` has to be equal to 3 modulo 4.

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -19,7 +19,7 @@ pub use miller_rabin::{MillerRabin, minimum_mr_iterations};
 pub use primecount::estimate_primecount;
 pub use sieve::{SetBits, SieveFactory, SmallFactorsSieve, SmallFactorsSieveFactory, random_odd_integer};
 
-use crypto_bigint::{Integer, Word};
+use crypto_bigint::{Unsigned, Word};
 
 /// Possible results of various primality tests.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -46,7 +46,7 @@ impl Primality {
 
 pub(crate) fn equals_primitive<T>(num: &T, primitive: Word) -> bool
 where
-    T: Integer,
+    T: Unsigned,
 {
     num.bits_vartime() <= Word::BITS && num.as_ref()[0].0 == primitive
 }

--- a/src/hazmat/gcd.rs
+++ b/src/hazmat/gcd.rs
@@ -1,12 +1,12 @@
 use core::num::NonZero;
-use crypto_bigint::{Integer, Limb, NonZero as CTNonZero, Word};
+use crypto_bigint::{Limb, NonZero as CTNonZero, Unsigned, Word};
 
 /// Calculates the greatest common divisor of `n` and `m`.
 /// By definition, `gcd(0, m) == m`.
 /// `n` must be non-zero.
 pub(crate) fn gcd_vartime<T>(n: &T, m: NonZero<Word>) -> Word
 where
-    T: Integer,
+    T: Unsigned,
 {
     let m = m.get();
     // This we can check since it doesn't affect the return type,

--- a/src/hazmat/jacobi.rs
+++ b/src/hazmat/jacobi.rs
@@ -1,6 +1,6 @@
 //! Jacobi symbol calculation.
 
-use crypto_bigint::{Integer, Limb, NonZero as CTNonZero, Odd, Word};
+use crypto_bigint::{Limb, NonZero as CTNonZero, Odd, Unsigned, Word};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum JacobiSymbol {
@@ -38,7 +38,7 @@ fn apply_reduce_numerator(j: JacobiSymbol, a: Word, p: Word) -> (JacobiSymbol, W
 
 fn reduce_numerator_long<T>(j: JacobiSymbol, a: Word, p: &T) -> (JacobiSymbol, Word)
 where
-    T: Integer,
+    T: Unsigned,
 {
     apply_reduce_numerator(j, a, p.as_ref()[0].0)
 }
@@ -54,7 +54,7 @@ fn apply_swap(j: JacobiSymbol, a: Word, p: Word) -> JacobiSymbol {
     if a & 3 == 1 || p & 3 == 1 { j } else { -j }
 }
 
-fn swap_long<T: Integer>(j: JacobiSymbol, a: Word, p: &Odd<T>) -> (JacobiSymbol, &Odd<T>, Word) {
+fn swap_long<T: Unsigned>(j: JacobiSymbol, a: Word, p: &Odd<T>) -> (JacobiSymbol, &Odd<T>, Word) {
     let j = apply_swap(j, a, p.as_ref().as_ref()[0].0);
     (j, p, a)
 }
@@ -67,7 +67,7 @@ fn swap_short(j: JacobiSymbol, a: Word, p: Word) -> (JacobiSymbol, Word, Word) {
 /// Returns the Jacobi symbol `(a/p)` given an odd `p`.
 pub(crate) fn jacobi_symbol_vartime<T>(abs_a: Word, a_is_negative: bool, p_long: &Odd<T>) -> JacobiSymbol
 where
-    T: Integer,
+    T: Unsigned,
 {
     let result = JacobiSymbol::One; // Keep track of all the sign flips here.
 

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -1,6 +1,6 @@
 //! Miller-Rabin primality test.
 
-use crypto_bigint::{Integer, Limb, Monty, NonZero as CTNonZero, Odd, PowBoundedExp, RandomMod, Square};
+use crypto_bigint::{Limb, Monty, NonZero as CTNonZero, Odd, PowBoundedExp, RandomMod, Square, Unsigned};
 use rand_core::CryptoRng;
 
 use super::{
@@ -21,18 +21,18 @@ use super::{
 ///
 /// [^FIPS]: FIPS-186.5 standard, <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf>
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct MillerRabin<T: Integer> {
+pub struct MillerRabin<T: Unsigned> {
     // The odd number that may or may not be a prime.
     candidate: T,
     /// The number of bits necessesary to represent the candidate. Note: this is not the number of
     /// bits used by a `T` in memory.
     bits: u32,
     /// Pre-computed parameters for the Montgomery form of `T`.
-    montgomery_params: <<T as Integer>::Monty as Monty>::Params,
+    montgomery_params: <<T as Unsigned>::Monty as Monty>::Params,
     /// The number 1 in Montgomery form.
-    one: <T as Integer>::Monty,
+    one: <T as Unsigned>::Monty,
     /// The number -1 in Montgomery form.
-    minus_one: <T as Integer>::Monty,
+    minus_one: <T as Unsigned>::Monty,
     /// The `s` exponent in the Miller-Rabin test, that finds `s` and `d` odd s.t. `candidate - 1 ==
     /// 2^s * d` (the pair `s` and `d` is unique).
     s: u32,
@@ -41,11 +41,11 @@ pub struct MillerRabin<T: Integer> {
     d: T,
 }
 
-impl<T: Integer + RandomMod> MillerRabin<T> {
+impl<T: Unsigned + RandomMod> MillerRabin<T> {
     /// Initializes a Miller-Rabin test for `candidate`.
     pub fn new(candidate: Odd<T>) -> Self {
-        let params = <T as Integer>::Monty::new_params_vartime(candidate.clone());
-        let m_one = <T as Integer>::Monty::one(params.clone());
+        let params = <T as Unsigned>::Monty::new_params_vartime(candidate.clone());
+        let m_one = <T as Unsigned>::Monty::one(params.clone());
         let m_minus_one = -m_one.clone();
 
         let one = T::one_like(candidate.as_ref());
@@ -79,7 +79,7 @@ impl<T: Integer + RandomMod> MillerRabin<T> {
         // One could check here if `gcd(base, candidate) == 1` and return `Composite` otherwise.
         // In practice it doesn't make any performance difference in normal operation.
 
-        let base = <T as Integer>::Monty::new(base.clone(), self.montgomery_params.clone());
+        let base = <T as Unsigned>::Monty::new(base.clone(), self.montgomery_params.clone());
 
         // Implementation detail: bounded exp gets faster every time we decrease the bound
         // by the window length it uses, which is currently 4 bits.
@@ -233,7 +233,7 @@ mod tests {
     use alloc::format;
     use core::num::NonZero;
 
-    use crypto_bigint::{Integer, Odd, RandomMod, U64, U128, U1024, U1536, Uint};
+    use crypto_bigint::{Odd, RandomMod, U64, U128, U1024, U1536, Uint, Unsigned};
     use rand_chacha::ChaCha8Rng;
     use rand_core::{CryptoRng, OsRng, SeedableRng, TryRngCore};
 
@@ -263,7 +263,7 @@ mod tests {
         pseudoprimes::STRONG_BASE_2.contains(&num)
     }
 
-    fn random_checks<T: Integer + RandomMod, R: CryptoRng + ?Sized>(
+    fn random_checks<T: Unsigned + RandomMod, R: CryptoRng + ?Sized>(
         rng: &mut R,
         mr: &MillerRabin<T>,
         count: usize,

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -5,7 +5,7 @@ use alloc::{vec, vec::Vec};
 use core::marker::PhantomData;
 use core::num::{NonZero, NonZeroU32};
 
-use crypto_bigint::{Integer, Odd, RandomBits, RandomBitsError};
+use crypto_bigint::{Odd, RandomBits, RandomBitsError, Unsigned};
 use rand_core::CryptoRng;
 
 use super::precomputed::{LAST_SMALL_PRIME, RECIPROCALS, SMALL_PRIMES, SmallPrime};
@@ -35,7 +35,7 @@ pub enum SetBits {
 /// (applies to fixed-length types).
 pub fn random_odd_integer<T, R>(rng: &mut R, bit_length: NonZeroU32, set_bits: SetBits) -> Result<Odd<T>, Error>
 where
-    T: Integer + RandomBits,
+    T: Unsigned + RandomBits,
     R: CryptoRng + ?Sized,
 {
     let bit_length = bit_length.get();
@@ -88,7 +88,7 @@ const INCR_LIMIT: Residue = Residue::MAX - LAST_SMALL_PRIME as Residue + 1;
 /// An iterator returning numbers with up to and including given bit length,
 /// starting from a given number, that are not multiples of the first 2048 small primes.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SmallFactorsSieve<T: Integer> {
+pub struct SmallFactorsSieve<T: Unsigned> {
     // Instead of dividing a big integer by small primes every time (which is slow),
     // we keep a "base" and a small increment separately,
     // so that we can only calculate the residues of the increment.
@@ -105,7 +105,7 @@ pub struct SmallFactorsSieve<T: Integer> {
 
 impl<T> SmallFactorsSieve<T>
 where
-    T: Integer,
+    T: Unsigned,
 {
     /// Creates a new sieve, iterating from `start` and until the last number with `max_bit_length`
     /// bits, producing numbers that are not non-trivial multiples of a list of small primes in the
@@ -290,7 +290,7 @@ where
 
 impl<T> Iterator for SmallFactorsSieve<T>
 where
-    T: Integer,
+    T: Unsigned,
 {
     type Item = T;
 
@@ -330,7 +330,7 @@ pub struct SmallFactorsSieveFactory<T> {
 
 impl<T> SmallFactorsSieveFactory<T>
 where
-    T: Integer + RandomBits,
+    T: Unsigned + RandomBits,
 {
     /// Creates a factory that produces sieves returning numbers of at most `max_bit_length` bits
     /// that are not divisible by a number of small factors.
@@ -372,7 +372,7 @@ where
 
 impl<T> SieveFactory for SmallFactorsSieveFactory<T>
 where
-    T: Integer + RandomBits,
+    T: Unsigned + RandomBits,
 {
     type Item = T;
     type Sieve = SmallFactorsSieve<T>;

--- a/src/multicore.rs
+++ b/src/multicore.rs
@@ -1,6 +1,6 @@
 //! Prime-finding functions that can parallelize across multiple cores.
 
-use crypto_bigint::{Integer, RandomBits, RandomMod};
+use crypto_bigint::{RandomBits, RandomMod, Unsigned};
 use rand_core::CryptoRng;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 
@@ -107,7 +107,7 @@ where
 /// Panics if the platform is unable to spawn threads.
 pub fn random_prime<T, R>(rng: &mut R, flavor: Flavor, bit_length: u32, threadcount: usize) -> T
 where
-    T: Integer + RandomBits + RandomMod,
+    T: Unsigned + RandomBits + RandomMod,
     R: CryptoRng + Send + Sync + Clone,
 {
     let factory = SmallFactorsSieveFactory::new(flavor, bit_length, SetBits::Msb)

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -1,4 +1,4 @@
-use crypto_bigint::{Integer, Odd, RandomBits, RandomMod};
+use crypto_bigint::{Odd, RandomBits, RandomMod, Unsigned};
 use rand_core::CryptoRng;
 
 use crate::{
@@ -26,7 +26,7 @@ pub enum Flavor {
 /// See [`is_prime`] for details about the performed checks.
 pub fn random_prime<T, R>(rng: &mut R, flavor: Flavor, bit_length: u32) -> T
 where
-    T: Integer + RandomBits + RandomMod,
+    T: Unsigned + RandomBits + RandomMod,
     R: CryptoRng + ?Sized,
 {
     let factory = SmallFactorsSieveFactory::new(flavor, bit_length, SetBits::Msb)
@@ -62,7 +62,7 @@ where
 ///       DOI: [10.1090/mcom/3616](https://doi.org/10.1090/mcom/3616)
 pub fn is_prime<T>(flavor: Flavor, candidate: &T) -> bool
 where
-    T: Integer + RandomMod,
+    T: Unsigned + RandomMod,
 {
     match flavor {
         Flavor::Any => {}
@@ -100,7 +100,7 @@ where
 /// See [`is_prime`] for details about the performed checks.
 fn is_safe_prime<T>(candidate: &T) -> bool
 where
-    T: Integer + RandomMod,
+    T: Unsigned + RandomMod,
 {
     // Since, by the definition of safe prime, `(candidate - 1) / 2` must also be prime,
     // and therefore odd, `candidate` has to be equal to 3 modulo 4.
@@ -121,7 +121,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crypto_bigint::{BoxedUint, CheckedAdd, Integer, RandomMod, U64, U128, Uint, Word, nlimbs};
+    use crypto_bigint::{BoxedUint, CheckedAdd, RandomMod, U64, U128, Uint, Unsigned, Word, nlimbs};
     use num_prime::nt_funcs::is_prime64;
     use rand_core::{OsRng, TryRngCore};
 
@@ -131,7 +131,7 @@ mod tests {
         hazmat::{minimum_mr_iterations, primes, pseudoprimes},
     };
 
-    fn fips_is_prime<T: Integer + RandomMod>(flavor: Flavor, num: &T) -> bool {
+    fn fips_is_prime<T: Unsigned + RandomMod>(flavor: Flavor, num: &T) -> bool {
         let mr_iterations = minimum_mr_iterations(128, 100).unwrap();
         fips::is_prime(&mut OsRng.unwrap_mut(), flavor, num, mr_iterations, false)
     }


### PR DESCRIPTION
Companion PR to RustCrypto/crypto-bigint#943 which makes it possible to impl the `Integer` trait for the `Int` type, and moves functionality like the associated `Monty` type to the `Unsigned` trait.

This is effectively a wholesale `s/Integer/Unsigned/`.