### PR TITLE
chore: align rustfmt.toml with Cargo.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 max_width = 120
+edition = "2024"


### PR DESCRIPTION
Some editors (rust.vim at least) will rely on the `rustfmt.toml` only and not read the `Cargo.toml` to format files on save. This commit aligns the format `cargo fmt` will use with what a raw `rustfmt` call will.