### PR TITLE
CI: fix `cargo semver-checks`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: ci
 on:
   workflow_dispatch:
   pull_request:
-    paths-ignore: [README.md]
+    paths-ignore: [ README.md ]
   push:
     branches: master
-    paths-ignore: [README.md]
+    paths-ignore: [ README.md ]
 
 env:
   CARGO_INCREMENTAL: 0
@@ -143,6 +143,7 @@ jobs:
           components: rustfmt
           profile: minimal
           override: true
+      - run: rm .cargo/config.toml # HACK: remove rustdocflags to avoid breaking build
       - uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           package: crypto-primes


### PR DESCRIPTION
`--html-in-header` apparently only works with the `--no-deps` option when `cargo doc` is invoked, which `cargo semver-checks` isn't doing

This removes the rustdocflags overrides in `.cargo/config.toml` by deleting the file first.