### PR TITLE
Bump `crypto-bigint` to v0.7.0-rc.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-crypto-bigint = { version = "0.7.0-pre.10", default-features = false, features = ["rand_core"] }
+crypto-bigint = { version = "0.7.0-rc.11", default-features = false, features = ["rand_core"] }
 libm = { version = "0.2.13", default-features = false, features = ["arch"] }
-rand_core = { version = "0.10.0-rc.2", default-features = false }
+rand_core = { version = "0.10.0-rc-3", default-features = false }
 rayon = { version = "1", optional = true, default-features = false }
 
 # Optional dependencies used in tests and benchmarks
@@ -21,9 +21,9 @@ rug = { version = "1.26", optional = true, default-features = false, features = 
 glass_pumpkin = { version = "1", optional = true }
 
 [dev-dependencies]
-rand = { version = "0.10.0-rc.1", features = ["chacha"] }
+rand = { version = "0.10.0-rc.5", features = ["chacha"] }
 # need `crypto-bigint` with `alloc` to test `BoxedUint`
-crypto-bigint = { version = "0.7.0-pre.10", default-features = false, features = ["alloc"] }
+crypto-bigint = { version = "0.7.0-pre.11", default-features = false, features = ["alloc"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 num-modular = { version = "0.5", features = ["num-bigint"] }
 num-bigint = "0.4"
@@ -61,3 +61,6 @@ harness = false
 [[bench]]
 name = "cctv"
 harness = false
+
+[patch.crates-io]
+rand = { git = "https://github.com/rust-random/rand" }

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -129,7 +129,7 @@ impl<T: Unsigned + RandomMod> MillerRabin<T> {
         let range_nonzero = CTNonZero::new(range).expect("the range should be non-zero by construction");
         // This should not overflow as long as `random_mod()` behaves according to the contract
         // (that is, returns a number within the given range).
-        let random = T::random_mod(rng, &range_nonzero)
+        let random = T::random_mod_vartime(rng, &range_nonzero)
             .checked_add(&T::from(2u32))
             .expect("addition should not overflow by construction");
         self.test(&random)

--- a/src/hazmat/precomputed.rs
+++ b/src/hazmat/precomputed.rs
@@ -131,7 +131,7 @@ const fn create_reciprocals() -> [Reciprocal; SMALL_PRIMES.len()] {
         arr[i] = Reciprocal::new(
             Limb(SMALL_PRIMES[i] as Word)
                 .to_nz()
-                .expect("divisor should be non-zero"),
+                .expect_copied("divisor should be non-zero"),
         );
         i += 1;
     }
@@ -155,7 +155,7 @@ mod tests {
 
         for (reciprocal, prime) in reciprocals.iter().zip(SMALL_PRIMES.iter()) {
             for _ in 0..10 {
-                let x = U256::random(&mut rng);
+                let x = U256::random_from_rng(&mut rng);
                 let r_ref = (x % NonZero::new(U256::from(*prime)).unwrap()).as_limbs()[0];
                 let r_test = x.rem_limb_with_reciprocal(reciprocal);
                 assert_eq!(r_ref, r_test);

--- a/src/multicore.rs
+++ b/src/multicore.rs
@@ -83,7 +83,7 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(result) = self.sieve.next() {
-                return Some((R::from_rng(self.rng), result));
+                return Some((self.rng.fork(), result));
             }
 
             self.sieve = self


### PR DESCRIPTION
This also includes @baloo's `rand_core` v0.10.0-rc-3 bump from #98.

This release switches `crypto-bigint` from `subtle` to `ctutils`, which seems to have surprisingly little impact on `crypto-primes`.