### PR TITLE
Bump `crypto-bigint` to v0.7 final release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-crypto-bigint = { version = "0.7.0-rc.27", default-features = false, features = ["rand_core"] }
+crypto-bigint = { version = "0.7", default-features = false, features = ["rand_core"] }
 libm = { version = "0.2.13", default-features = false, features = ["arch"] }
 rand_core = { version = "0.10", default-features = false }
 rayon = { version = "1", optional = true, default-features = false }
@@ -23,7 +23,7 @@ glass_pumpkin = { version = "1", optional = true }
 [dev-dependencies]
 rand = { version = "0.10", features = ["chacha"] }
 # need `crypto-bigint` with `alloc` to test `BoxedUint`
-crypto-bigint = { version = "0.7.0-pre.27", default-features = false, features = ["alloc"] }
+crypto-bigint = { version = "0.7", default-features = false, features = ["alloc"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 num-modular = { version = "0.5", features = ["num-bigint"] }
 num-bigint = "0.4"

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -631,7 +631,7 @@ mod tests {
     fn base_for_square() {
         // We can't find a base with Jacobi symbol = -1 for a square,
         // check that it is handled properly.
-        let num = Odd::new(U64::from(131u32).square()).unwrap();
+        let num = Odd::new(U64::from(131u32).concatenating_square()).unwrap();
         assert_eq!(SelfridgeBase.generate(&num), Err(Primality::Composite));
         assert_eq!(AStarBase.generate(&num), Err(Primality::Composite));
         assert_eq!(BruteForceBase.generate(&num), Err(Primality::Composite));


### PR DESCRIPTION
Release PR: RustCrypto/crypto-bigint#1218