### PR TITLE
Housekeeping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          # Temporary disables codecov binary check due to codecov bug.
+          skip_validation: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,8 @@ jobs:
       - name: Generate coverage report
         run: cargo llvm-cov report --output-path lcov.info
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
-          # Temporary disables codecov binary check due to codecov bug.
-          skip_validation: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,12 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Test in release
         run: cargo test --features multicore --benches --workspace --release
-      - name: Generate code coverage
-        run: cargo llvm-cov --features multicore --workspace --lcov --output-path lcov.info
+      - name: Generate code coverage (no-alloc)
+        run: cargo llvm-cov --no-default-features --workspace --lcov --no-report
+      - name: Generate code coverage (main features)
+        run: cargo llvm-cov --features multicore --workspace --lcov --no-report
+      - name: Generate coverage report
+        run: cargo llvm-cov report --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.1] - in development
+
+### Added
+
+- All heap allocation is now gated under the `alloc` feature (enabled by default). ([#118])
+
+
+[#118]: https://github.com/entropyxyz/crypto-primes/pull/118
+
+
 ## [0.7.0] - 2026-03-09
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-primes"
-version = "0.7.0"
+version = "0.7.1-dev"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 description = "Random prime number generation and primality checking library"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,54 @@ harness = false
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = ['cfg(cpubits, values("16", "32", "64"))']
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+perf = { level = "warn", priority = -1 }
+suspicious = { level = "warn", priority = -1 }
+correctness = { level = "warn", priority = -1 }
+complexity = { level = "warn", priority = -1 }
+style = { level = "warn", priority = -1 }
+
+# Good idea, but if you implement this change,
+# the compiler complains about a `pub(crate)` item being exported as `pub`.
+redundant_pub_crate = "allow"
+
+# Too restrictive, sometimes there's not need to specifically describe errors.
+missing_errors_doc = "allow"
+
+# Math code. What can you do.
+similar-names = "allow"
+many_single_char_names = "allow"
+
+# We have a lot of those, they are often copy-pasted from prime/pseudoprime databases,
+# and they can't be fixed automatically. Allowing for now.
+unreadable_literal = "allow"
+
+# Unfortunately it does not distinguish between panics that may occur for some inputs
+# and panics that may only occur if there is a bug in the code (expects).
+missing_panics_doc = "allow"
+
+# Select warning from the `restriction` category.
+alloc_instead_of_core = "warn"
+allow_attributes = "warn"
+as_conversions = "warn"
+indexing_slicing = "warn"
+mod_module_files = "warn"
+unwrap_used = "warn"
+
+# Due to https://github.com/rust-lang/rust-clippy/issues/13885, triggers on clippy.toml
+# TODO: can be removed when MSRV and therefore the clippy version in CI is 1.87 or higher.
+literal_string_with_formatting_args = "allow"
+
+[lints.rust]
+rust_2018_idioms = { level = "warn", priority = -1 }
+missing_copy_implementations = { level = "warn" }
+missing_debug_implementations = { level = "warn" }
+trivial_casts = { level = "warn" }
+trivial_numeric_casts = { level = "warn" }
+missing_docs = { level = "warn" }
+unused_qualifications = { level = "warn" }
+unsafe_code = { level = "deny" }

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ assert!(is_prime(flavor, &prime));
 
 The following features are available:
 
-- `multicore`: Enables additional parallel prime finding functions. Disabled by default.
+- `alloc`: Use heap allocations (enabled by default).
+- `multicore`: Enables additional parallel prime finding functions.
 
 
 [crate-image]: https://img.shields.io/crates/v/crypto-primes.svg

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,3 +1,10 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::significant_drop_tightening, // Bugged with Criterion groups.
+    missing_docs,
+)]
+
 use core::num::NonZero;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
@@ -434,7 +441,7 @@ fn bench_openssl(c: &mut Criterion) {
             || BigNum::new().unwrap(),
             |p| {
                 let mut p = p;
-                p.generate_prime(128, false, None, None).unwrap()
+                p.generate_prime(128, false, None, None).unwrap();
             },
             BatchSize::SmallInput,
         );
@@ -445,7 +452,7 @@ fn bench_openssl(c: &mut Criterion) {
             || BigNum::new().unwrap(),
             |p| {
                 let mut p = p;
-                p.generate_prime(1024, false, None, None).unwrap()
+                p.generate_prime(1024, false, None, None).unwrap();
             },
             BatchSize::SmallInput,
         );
@@ -456,7 +463,7 @@ fn bench_openssl(c: &mut Criterion) {
             || BigNum::new().unwrap(),
             |p| {
                 let mut p = p;
-                p.generate_prime(128, true, None, None).unwrap()
+                p.generate_prime(128, true, None, None).unwrap();
             },
             BatchSize::SmallInput,
         );
@@ -468,7 +475,7 @@ fn bench_openssl(c: &mut Criterion) {
             || BigNum::new().unwrap(),
             |p| {
                 let mut p = p;
-                p.generate_prime(1024, true, None, None).unwrap()
+                p.generate_prime(1024, true, None, None).unwrap();
             },
             BatchSize::SmallInput,
         );
@@ -488,6 +495,7 @@ fn bench_glass_pumpkin(c: &mut Criterion) {
     // The `glass-pumpkin` implementation is doing a different number of M-R checks than this crate.
     // For a fair comparison we make a custom implementation here,
     // using the same number of checks that `glass-pumpkin` does.
+    #[expect(clippy::as_conversions, clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     fn required_checks(bits: u32) -> usize {
         (f64::from(bits).log2() as usize) + 5
     }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -51,7 +51,7 @@ fn bench_sieve(c: &mut Criterion) {
     let mut rng = rand::rng();
 
     group.bench_function("(U128) random start", |b| {
-        b.iter(|| random_odd_uint::<U128, _>(&mut rng, 128))
+        b.iter(|| random_odd_uint::<U128, _>(&mut rng, 128));
     });
 
     group.bench_function("(U128) creation", |b| {
@@ -59,7 +59,7 @@ fn bench_sieve(c: &mut Criterion) {
             || random_odd_uint::<U128, _>(&mut rng, 128),
             |start| SmallFactorsSieve::new(start.get(), NonZero::new(128).unwrap(), false),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     // 5 is the average number of pre-sieved samples we need to take before we encounter a prime
@@ -68,11 +68,11 @@ fn bench_sieve(c: &mut Criterion) {
             || make_sieve::<{ nlimbs(128) }, _>(&mut rng),
             |sieve| sieve.take(5).for_each(drop),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("(U1024) random start", |b| {
-        b.iter(|| random_odd_uint::<U1024, _>(&mut rng, 1024))
+        b.iter(|| random_odd_uint::<U1024, _>(&mut rng, 1024));
     });
 
     group.bench_function("(U1024) creation", |b| {
@@ -80,7 +80,7 @@ fn bench_sieve(c: &mut Criterion) {
             || random_odd_uint::<U1024, _>(&mut rng, 1024),
             |start| SmallFactorsSieve::new(start.get(), NonZero::new(1024).unwrap(), false),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     // 42 is the average number of pre-sieved samples we need to take before we encounter a prime
@@ -89,7 +89,7 @@ fn bench_sieve(c: &mut Criterion) {
             || make_sieve::<{ nlimbs(1024) }, _>(&mut rng),
             |sieve| sieve.take(42).for_each(drop),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     // 42^2 is the average number of pre-sieved samples we need to take
@@ -99,10 +99,10 @@ fn bench_sieve(c: &mut Criterion) {
             || make_sieve::<{ nlimbs(1024) }, _>(&mut rng),
             |sieve| sieve.take(42 * 42).for_each(drop),
             BatchSize::SmallInput,
-        )
+        );
     });
 
-    group.finish()
+    group.finish();
 }
 
 fn bench_miller_rabin(c: &mut Criterion) {
@@ -114,7 +114,7 @@ fn bench_miller_rabin(c: &mut Criterion) {
             || random_odd_uint::<U128, _>(&mut rng, 128),
             MillerRabin::<U128>::new,
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("(U128) random base test (pre-sieved)", |b| {
@@ -122,7 +122,7 @@ fn bench_miller_rabin(c: &mut Criterion) {
             || MillerRabin::new(make_presieved_num::<{ nlimbs(128) }, _>(&mut rng.clone())),
             |mr| mr.test_random_base(&mut rng.clone()),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("(U1024) creation", |b| {
@@ -130,7 +130,7 @@ fn bench_miller_rabin(c: &mut Criterion) {
             || random_odd_uint::<U1024, _>(&mut rng, 1024),
             MillerRabin::<U1024>::new,
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("(U1024) random base test (pre-sieved)", |b| {
@@ -138,7 +138,7 @@ fn bench_miller_rabin(c: &mut Criterion) {
             || MillerRabin::new(make_presieved_num::<{ nlimbs(1024) }, _>(&mut rng.clone())),
             |mr| mr.test_random_base(&mut rng.clone()),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 
@@ -151,7 +151,7 @@ fn bench_lucas(c: &mut Criterion) {
             || make_presieved_num::<{ nlimbs(128) }, _>(&mut rng),
             |n| lucas_test(n, SelfridgeBase, LucasCheck::Strong),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     let mut rng = make_rng();
@@ -160,7 +160,7 @@ fn bench_lucas(c: &mut Criterion) {
             || make_presieved_num::<{ nlimbs(1024) }, _>(&mut rng),
             |n| lucas_test(n, SelfridgeBase, LucasCheck::Strong),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     let mut rng = make_rng();
@@ -169,7 +169,7 @@ fn bench_lucas(c: &mut Criterion) {
             || make_presieved_num::<{ nlimbs(1024) }, _>(&mut rng),
             |n| lucas_test(n, AStarBase, LucasCheck::LucasV),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     let mut rng = make_rng();
@@ -178,7 +178,7 @@ fn bench_lucas(c: &mut Criterion) {
             || make_presieved_num::<{ nlimbs(1024) }, _>(&mut rng),
             |n| lucas_test(n, BruteForceBase, LucasCheck::AlmostExtraStrong),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     let mut rng = make_rng();
@@ -187,7 +187,7 @@ fn bench_lucas(c: &mut Criterion) {
             || make_presieved_num::<{ nlimbs(1024) }, _>(&mut rng),
             |n| lucas_test(n, BruteForceBase, LucasCheck::ExtraStrong),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     // A number triggering a slow path through the Lucas test, invoking all the available checks:
@@ -206,7 +206,7 @@ fn bench_lucas(c: &mut Criterion) {
     group.bench_function("(U1024) Selfridge base, strong check, slow path", |b| {
         b.iter(|| {
             lucas_test(slow_path, SelfridgeBase, LucasCheck::Strong);
-        })
+        });
     });
 
     group.finish();
@@ -221,7 +221,7 @@ fn bench_presets(c: &mut Criterion) {
             || random_odd_uint::<U128, _>(&mut rng, 128),
             |num| is_prime(Flavor::Any, num.as_ref()),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("(U1024) Prime test", |b| {
@@ -229,7 +229,7 @@ fn bench_presets(c: &mut Criterion) {
             || random_odd_uint::<U1024, _>(&mut rng, 1024),
             |num| is_prime(Flavor::Any, num.as_ref()),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     let iters = minimum_mr_iterations(1024, 128).unwrap();
@@ -248,7 +248,7 @@ fn bench_presets(c: &mut Criterion) {
                     )
                 },
                 BatchSize::SmallInput,
-            )
+            );
         },
     );
 
@@ -266,7 +266,7 @@ fn bench_presets(c: &mut Criterion) {
                     )
                 },
                 BatchSize::SmallInput,
-            )
+            );
         },
     );
 
@@ -275,39 +275,39 @@ fn bench_presets(c: &mut Criterion) {
             || random_odd_uint::<U128, _>(&mut rng, 128),
             |num| is_prime(Flavor::Safe, num.as_ref()),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random prime", |b| {
-        b.iter(|| random_prime::<U128, _>(&mut rng, Flavor::Any, 128))
+        b.iter(|| random_prime::<U128, _>(&mut rng, Flavor::Any, 128));
     });
 
     let mut rng = make_rng();
     group.bench_function("(U1024) Random prime", |b| {
-        b.iter(|| random_prime::<U1024, _>(&mut rng, Flavor::Any, 1024))
+        b.iter(|| random_prime::<U1024, _>(&mut rng, Flavor::Any, 1024));
     });
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random safe prime", |b| {
-        b.iter(|| random_prime::<U128, _>(&mut rng, Flavor::Safe, 128))
+        b.iter(|| random_prime::<U128, _>(&mut rng, Flavor::Safe, 128));
     });
 
     group.sample_size(20);
     let mut rng = make_rng();
     group.bench_function("(U1024) Random safe prime", |b| {
-        b.iter(|| random_prime::<U1024, _>(&mut rng, Flavor::Safe, 1024))
+        b.iter(|| random_prime::<U1024, _>(&mut rng, Flavor::Safe, 1024));
     });
 
     let mut rng = make_rng();
     group.bench_function("(Boxed128) Random safe prime", |b| {
-        b.iter(|| random_prime::<BoxedUint, _>(&mut rng, Flavor::Safe, 128))
+        b.iter(|| random_prime::<BoxedUint, _>(&mut rng, Flavor::Safe, 128));
     });
 
     group.sample_size(20);
     let mut rng = make_rng();
     group.bench_function("(Boxed1024) Random safe prime", |b| {
-        b.iter(|| random_prime::<BoxedUint, _>(&mut rng, Flavor::Safe, 1024))
+        b.iter(|| random_prime::<BoxedUint, _>(&mut rng, Flavor::Safe, 1024));
     });
 
     group.finish();
@@ -317,19 +317,19 @@ fn bench_presets(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("(U128) Random safe prime", |b| {
-        b.iter(|| random_prime::<U128, _>(&mut rng, Flavor::Safe, 128))
+        b.iter(|| random_prime::<U128, _>(&mut rng, Flavor::Safe, 128));
     });
 
     // The performance should scale with the prime size, not with the Uint size.
     // So we should strive for this test's result to be as close as possible
     // to that of the previous one and as far away as possible from the next one.
     group.bench_function("(U256) Random 128 bit safe prime", |b| {
-        b.iter(|| random_prime::<U256, _>(&mut rng, Flavor::Safe, 128))
+        b.iter(|| random_prime::<U256, _>(&mut rng, Flavor::Safe, 128));
     });
 
     // The upper bound for the previous test.
     group.bench_function("(U256) Random 256 bit safe prime", |b| {
-        b.iter(|| random_prime::<U256, _>(&mut rng, Flavor::Safe, 256))
+        b.iter(|| random_prime::<U256, _>(&mut rng, Flavor::Safe, 256));
     });
 
     group.finish();
@@ -344,7 +344,7 @@ fn bench_multicore_presets(c: &mut Criterion) {
             make_random_rng,
             |mut rng| multicore::random_prime::<U128, _>(&mut rng, Flavor::Any, 128, num_cpus::get()),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("(U1024) Random prime", |b| {
@@ -352,7 +352,7 @@ fn bench_multicore_presets(c: &mut Criterion) {
             make_random_rng,
             |mut rng| multicore::random_prime::<U1024, _>(&mut rng, Flavor::Any, 1024, num_cpus::get()),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("(U128) Random safe prime", |b| {
@@ -360,7 +360,7 @@ fn bench_multicore_presets(c: &mut Criterion) {
             make_random_rng,
             |mut rng| multicore::random_prime::<U128, _>(&mut rng, Flavor::Safe, 128, num_cpus::get()),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.sample_size(20);
@@ -369,7 +369,7 @@ fn bench_multicore_presets(c: &mut Criterion) {
             make_random_rng,
             |mut rng| multicore::random_prime::<U1024, _>(&mut rng, Flavor::Safe, 1024, num_cpus::get()),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("(Boxed128) Random safe prime", |b| {
@@ -377,7 +377,7 @@ fn bench_multicore_presets(c: &mut Criterion) {
             make_random_rng,
             |mut rng| multicore::random_prime::<BoxedUint, _>(&mut rng, Flavor::Safe, 128, num_cpus::get()),
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.sample_size(20);
@@ -386,7 +386,7 @@ fn bench_multicore_presets(c: &mut Criterion) {
             make_random_rng,
             |mut rng| multicore::random_prime::<BoxedUint, _>(&mut rng, Flavor::Safe, 1024, num_cpus::get()),
             BatchSize::SmallInput,
-        )
+        );
     });
 }
 
@@ -395,28 +395,28 @@ fn bench_multicore_presets(_c: &mut Criterion) {}
 
 #[cfg(feature = "tests-gmp")]
 fn bench_gmp(c: &mut Criterion) {
-    let mut group = c.benchmark_group("GMP");
-    let mut rng = rand::rng();
-
     fn random<const L: usize, R: CryptoRng + ?Sized>(rng: &mut R) -> GmpInteger {
         let num = random_odd_uint::<Uint<L>, R>(rng, Uint::<L>::BITS).get();
         GmpInteger::from_digits(num.as_words(), Order::Lsf)
     }
 
+    let mut group = c.benchmark_group("GMP");
+    let mut rng = rand::rng();
+
     group.bench_function("(U128) Random prime", |b| {
         b.iter_batched(
             || random::<{ nlimbs(128) }, _>(&mut rng),
-            |n| n.next_prime(),
+            rug::Integer::next_prime,
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("(U1024) Random prime", |b| {
         b.iter_batched(
             || random::<{ nlimbs(1024) }, _>(&mut rng),
-            |n| n.next_prime(),
+            rug::Integer::next_prime,
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.finish();
@@ -437,7 +437,7 @@ fn bench_openssl(c: &mut Criterion) {
                 p.generate_prime(128, false, None, None).unwrap()
             },
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("(U1024) Random prime", |b| {
@@ -448,7 +448,7 @@ fn bench_openssl(c: &mut Criterion) {
                 p.generate_prime(1024, false, None, None).unwrap()
             },
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.bench_function("(U128) Random safe prime", |b| {
@@ -459,7 +459,7 @@ fn bench_openssl(c: &mut Criterion) {
                 p.generate_prime(128, true, None, None).unwrap()
             },
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.sample_size(20);
@@ -471,7 +471,7 @@ fn bench_openssl(c: &mut Criterion) {
                 p.generate_prime(1024, true, None, None).unwrap()
             },
             BatchSize::SmallInput,
-        )
+        );
     });
 
     group.finish();
@@ -489,7 +489,7 @@ fn bench_glass_pumpkin(c: &mut Criterion) {
     // For a fair comparison we make a custom implementation here,
     // using the same number of checks that `glass-pumpkin` does.
     fn required_checks(bits: u32) -> usize {
-        ((bits as f64).log2() as usize) + 5
+        (f64::from(bits).log2() as usize) + 5
     }
 
     // Mimics the sequence of checks `glass-pumpkin` does to find a prime.
@@ -510,7 +510,7 @@ fn bench_glass_pumpkin(c: &mut Criterion) {
                 match lucas_test(odd_num, AStarBase, LucasCheck::Strong) {
                     Primality::Composite => continue,
                     Primality::Prime => return num,
-                    _ => {}
+                    Primality::ProbablyPrime => {}
                 }
 
                 return num;
@@ -555,7 +555,7 @@ fn bench_glass_pumpkin(c: &mut Criterion) {
                 match lucas_test(odd_half, AStarBase, LucasCheck::Strong) {
                     Primality::Composite => continue,
                     Primality::Prime => return num,
-                    _ => {}
+                    Primality::ProbablyPrime => {}
                 }
 
                 return num;
@@ -567,24 +567,24 @@ fn bench_glass_pumpkin(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("(U1024) Random prime (crypto-primes default)", |b| {
-        b.iter(|| random_prime::<BoxedUint, _>(&mut rng, Flavor::Any, 1024))
+        b.iter(|| random_prime::<BoxedUint, _>(&mut rng, Flavor::Any, 1024));
     });
 
     let mut rng = make_rng();
     group.bench_function("(U1024) Random prime (crypto-primes mimicking glass-pumpkin)", |b| {
-        b.iter(|| prime_like_gp(1024, &mut rng))
+        b.iter(|| prime_like_gp(1024, &mut rng));
     });
 
     let mut rng = make_rng();
     group.bench_function("(U1024) Random prime", |b| {
-        b.iter(|| glass_pumpkin::prime::from_rng(1024, &mut rng))
+        b.iter(|| glass_pumpkin::prime::from_rng(1024, &mut rng));
     });
 
     group.sample_size(20);
 
     let mut rng = make_rng();
     group.bench_function("(U1024) Random safe prime (crypto-primes default)", |b| {
-        b.iter(|| random_prime::<BoxedUint, _>(&mut rng, Flavor::Safe, 1024))
+        b.iter(|| random_prime::<BoxedUint, _>(&mut rng, Flavor::Safe, 1024));
     });
 
     let mut rng = make_rng();
@@ -595,7 +595,7 @@ fn bench_glass_pumpkin(c: &mut Criterion) {
 
     let mut rng = make_rng();
     group.bench_function("(U1024) Random safe prime", |b| {
-        b.iter(|| glass_pumpkin::safe_prime::from_rng(1024, &mut rng))
+        b.iter(|| glass_pumpkin::safe_prime::from_rng(1024, &mut rng));
     });
 }
 

--- a/benches/cctv.rs
+++ b/benches/cctv.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::indexing_slicing, missing_docs)]
+
 use std::io::BufRead;
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
-            Error::BitLengthTooLarge {
+            Self::BitLengthTooLarge {
                 bit_length,
                 bits_precision,
             } => write!(
@@ -35,7 +35,7 @@ impl fmt::Display for Error {
                 ],
                 bit_length, bits_precision
             ),
-            Error::BitLengthTooSmall { bit_length, flavor } => write!(
+            Self::BitLengthTooSmall { bit_length, flavor } => write!(
                 f,
                 concat![
                     "The requested bit length of the candidate ({}) ",

--- a/src/fips.rs
+++ b/src/fips.rs
@@ -8,7 +8,7 @@ use rand_core::CryptoRng;
 use crate::{
     hazmat::{
         ConventionsTestResult, LucasCheck, MillerRabin, Primality, SelfridgeBase, conventions_test, equals_primitive,
-        lucas_test, minimum_mr_iterations, small_factors_test,
+        first_limb, lucas_test, minimum_mr_iterations, small_factors_test,
     },
     presets::Flavor,
 };
@@ -140,7 +140,7 @@ where
     // Safe primes are always of the form 4k + 3 (i.e. n ≡ 3 mod 4)
     // The last two digits of a binary number give you its value modulo 4.
     // Primes p=4n+3 will always end in 11 in binary because p ≡ 3 mod 4.
-    if candidate.as_limbs()[0].0 & 3 != 3 {
+    if first_limb(candidate) & 3 != 3 {
         return false;
     }
 

--- a/src/fips.rs
+++ b/src/fips.rs
@@ -26,6 +26,7 @@ impl FipsOptions {
     ///
     /// The number of iterations given the required error bound can be calculated with
     /// [`minimum_mr_iterations`](`crate::hazmat::minimum_mr_iterations`).
+    #[must_use]
     pub const fn with_mr_iterations(mr_iterations: usize) -> Self {
         Self {
             mr_iterations,
@@ -36,10 +37,10 @@ impl FipsOptions {
 
     /// Use the minimum number of Miller-Rabin iterations (see [`MillerRabin`] for details)
     /// required for the error to be below `1/2^log2_target` for candidates of size `bit_length`.
+    #[must_use]
     pub const fn with_error_bound(bit_length: u32, log2_target: u32) -> Option<Self> {
-        let iterations = match minimum_mr_iterations(bit_length, log2_target) {
-            None => return None,
-            Some(iterations) => iterations,
+        let Some(iterations) = minimum_mr_iterations(bit_length, log2_target) else {
+            return None;
         };
         Some(Self::with_mr_iterations(iterations))
     }
@@ -47,6 +48,7 @@ impl FipsOptions {
     /// Use an additional strong Lucas test with Selfridge base (see [`lucas_test`] and [`SelfridgeBase`] for details).
     ///
     /// `false` by default.
+    #[must_use]
     pub const fn with_lucas_test(self) -> Self {
         Self {
             mr_iterations: self.mr_iterations,
@@ -62,6 +64,7 @@ impl FipsOptions {
     /// Note that it is a performance optimization for the cases when you expect the candidates to be random
     /// (and thus likely to have small factors).
     /// It does not affect the failure probability of the primality check.
+    #[must_use]
     pub const fn with_trial_division_test(self) -> Self {
         Self {
             mr_iterations: self.mr_iterations,

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -18,9 +18,8 @@ where
     // Unlike the parallel version, it is avoidable here.
 
     let mut sieve_factory = sieve_factory;
-    let mut sieve = match sieve_factory.make_sieve(rng, None)? {
-        Some(sieve) => sieve,
-        None => return Ok(None),
+    let Some(mut sieve) = sieve_factory.make_sieve(rng, None)? else {
+        return Ok(None);
     };
 
     loop {

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -37,19 +37,19 @@ pub enum Primality {
 
 impl Primality {
     /// Returns `true` if the result indicates that the number is definitely composite.
-    pub fn is_composite(&self) -> bool {
+    #[must_use]
+    pub const fn is_composite(&self) -> bool {
         match self {
-            Self::Prime => false,
-            Self::ProbablyPrime => false,
+            Self::Prime | Self::ProbablyPrime => false,
             Self::Composite => true,
         }
     }
 
     /// Returns `true` if the result indicates that the number is probably or definitely prime.
-    pub fn is_probably_prime(&self) -> bool {
+    #[must_use]
+    pub const fn is_probably_prime(&self) -> bool {
         match self {
-            Self::Prime => true,
-            Self::ProbablyPrime => true,
+            Self::Prime | Self::ProbablyPrime => true,
             Self::Composite => false,
         }
     }

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -13,13 +13,15 @@ pub(crate) mod primes;
 #[cfg(test)]
 pub(crate) mod pseudoprimes;
 mod sieve;
+mod utils;
 
 pub use lucas::{AStarBase, BruteForceBase, LucasBase, LucasCheck, SelfridgeBase, lucas_test};
 pub use miller_rabin::{MillerRabin, minimum_mr_iterations};
 pub use primecount::estimate_primecount;
 pub use sieve::{SetBits, SieveFactory, SmallFactorsSieve, SmallFactorsSieveFactory, random_odd_integer};
 
-pub(crate) use sieve::{ConventionsTestResult, conventions_test, equals_primitive, small_factors_test};
+pub(crate) use sieve::{ConventionsTestResult, conventions_test, small_factors_test};
+pub(crate) use utils::{equals_primitive, first_limb};
 
 /// Possible results of various primality tests.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/src/hazmat/float.rs
+++ b/src/hazmat/float.rs
@@ -18,7 +18,7 @@ const fn pow(mut base: f64, mut exp: u32) -> f64 {
 
 /// Calculates `2^exp`.
 pub(crate) const fn two_powi(exp: u32) -> f64 {
-    pow(2f64, exp.abs_diff(0))
+    pow(2f64, exp)
 }
 
 /// Calculates `floor(x)`.
@@ -27,6 +27,7 @@ const fn floor(x: f64) -> f64 {
     const TOINT: f64 = 1. / f64::EPSILON;
 
     let ui = x.to_bits();
+    #[expect(clippy::as_conversions)] // `ui` is pre-shifted so there will be no overflow
     let e = ((ui >> 52) & 0x7ff) as i32;
 
     if (e >= 0x3ff + 52) || (x == 0.) {
@@ -83,7 +84,10 @@ pub(crate) const fn two_powf_upper_bound(exp: f64) -> f64 {
 
     let frac_part = positive_exp - int_part;
 
+    // Can convert safely since we checked abouve that it is < 1075 and positive
+    #[expect(clippy::as_conversions, clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     let int_res = two_powi(int_part as u32);
+
     let frac_res = two_powf_normalized_lower_bound(frac_part);
 
     // `int_res * frac_res <= 2^(int_part + frac_part)`,
@@ -144,6 +148,9 @@ pub(crate) fn ln<const LIMBS: usize>(x: &Uint<LIMBS>) -> f64 {
                 }
             }
         };
+
+        // We don't mind losing precision here.
+        #[expect(clippy::as_conversions, clippy::cast_precision_loss)]
         return libm::log2(x as f64) * f64::consts::LN_2;
     }
     // x can be approximated by M*2^shift, where shift is `ilog2(x) - 52` and M is the integer value represented by the
@@ -151,19 +158,23 @@ pub(crate) fn ln<const LIMBS: usize>(x: &Uint<LIMBS>) -> f64 {
     // log2(x) ~ log2(M*2^shift) ~ log2(M) + shift ~ log2(M) + ilog2(x) - 52
     let shift = ilog2_x.saturating_sub(f64::MANTISSA_DIGITS - 1);
     let shifted_x = x.wrapping_shr_vartime(shift);
+
     let fraction = {
         cpubits! {
             32 => {
                 let lo = shifted_x.as_limbs()[0].0;
                 let hi = shifted_x.as_limbs()[1].0;
-                let fraction = (hi as u64) << 32 | lo as u64;
-                fraction as f64
+                (hi as u64) << 32 | lo as u64
             }
             64 => {
-                shifted_x.as_limbs()[0].0 as f64
+                shifted_x.as_limbs()[0].0
             }
         }
     };
+
+    // We don't mind losing precision here.
+    #[expect(clippy::as_conversions, clippy::cast_precision_loss)]
+    let fraction = fraction as f64;
 
     // Fraction is now m * 2^52, where m is the top 53 bits of x. Take log2(m) and subtract 52 to scale the result back
     // to the expected range.
@@ -219,6 +230,7 @@ mod tests {
         fn fuzzy_floor_sqrt(x in 0..100000u32) {
             let x_f = f64::from(x);
             let test = floor_sqrt(x);
+            #[expect(clippy::as_conversions, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             let reference = x_f.sqrt().floor() as u32;
             assert_eq!(test, reference);
         }

--- a/src/hazmat/float.rs
+++ b/src/hazmat/float.rs
@@ -47,6 +47,12 @@ const fn floor(x: f64) -> f64 {
 
 /// Calculates a lower bound approximation of `2^exp` where `0 <= exp <= 1`.
 const fn two_powf_normalized_lower_bound(exp: f64) -> f64 {
+    // The coefficients are `ln(2)^n / n!`, where `n` is the power of the corresponding term.
+    const LN_2: f64 = f64::consts::LN_2;
+    const C1: f64 = LN_2;
+    const C2: f64 = LN_2 * LN_2 / 2.;
+    const C3: f64 = LN_2 * LN_2 * LN_2 / 6.;
+
     debug_assert!(exp >= 0.);
     debug_assert!(exp <= 1.);
 
@@ -57,12 +63,6 @@ const fn two_powf_normalized_lower_bound(exp: f64) -> f64 {
 
     let exp_2 = exp * exp;
     let exp_3 = exp_2 * exp;
-
-    // The coefficients are `ln(2)^n / n!`, where `n` is the power of the corresponding term.
-    const LN_2: f64 = f64::consts::LN_2;
-    const C1: f64 = LN_2;
-    const C2: f64 = LN_2 * LN_2 / 2.;
-    const C3: f64 = LN_2 * LN_2 * LN_2 / 6.;
 
     1. + C1 * exp + C2 * exp_2 + C3 * exp_3
 }
@@ -96,7 +96,7 @@ pub(crate) const fn floor_sqrt(x: u32) -> u32 {
     let mut high = x / 2;
 
     while low <= high {
-        let mid = (low + high) / 2;
+        let mid = u32::midpoint(low, high);
         let mid_squared = mid * mid;
 
         // Check if `mid` is the floor of the square root of `x`.
@@ -105,11 +105,11 @@ pub(crate) const fn floor_sqrt(x: u32) -> u32 {
         } else if mid_squared < x {
             low = mid + 1;
         } else {
-            high = mid - 1
+            high = mid - 1;
         }
     }
 
-    (low + high) / 2
+    u32::midpoint(low, high)
 }
 
 // Calculate the natural logarithm of a big integer using the relation ln(x) = log₂(x) / log₂(e).
@@ -161,8 +161,8 @@ pub(crate) fn ln<const LIMBS: usize>(x: &Uint<LIMBS>) -> f64 {
 
     // Fraction is now m * 2^52, where m is the top 53 bits of x. Take log2(m) and subtract 52 to scale the result back
     // to the expected range.
-    let fraction = libm::log2(fraction) - (f64::MANTISSA_DIGITS - 1) as f64;
-    let log2_x = ilog2_x as f64 + fraction;
+    let fraction = libm::log2(fraction) - f64::from(f64::MANTISSA_DIGITS - 1);
+    let log2_x = f64::from(ilog2_x) + fraction;
     log2_x * f64::consts::LN_2
 }
 
@@ -187,9 +187,9 @@ mod tests {
     proptest! {
         #[test]
         fn fuzzy_pow(base in 0..100u32, exp in 0..30u32) {
-            let base_f = base as f64 / 100.;
+            let base_f = f64::from(base) / 100.;
             let test = pow(base_f, exp);
-            let reference = base_f.powf(exp as f64);
+            let reference = base_f.powf(f64::from(exp));
             assert_approx_eq!(f64, test, reference, ulps = 20);
         }
 
@@ -202,7 +202,7 @@ mod tests {
 
         #[test]
         fn fuzzy_two_powf_upper_bound(exp in 0..1000) {
-            let exp_f = exp as f64 / 1000.;
+            let exp_f = f64::from(exp) / 1000.;
             let test = two_powf_normalized_lower_bound(exp_f);
             let reference = 2f64.powf(exp_f);
             assert!(test <= reference);
@@ -211,7 +211,7 @@ mod tests {
 
         #[test]
         fn fuzzy_floor_sqrt(x in 0..100000u32) {
-            let x_f = x as f64;
+            let x_f = f64::from(x);
             let test = floor_sqrt(x);
             let reference = x_f.sqrt().floor() as u32;
             assert_eq!(test, reference);
@@ -263,7 +263,7 @@ mod tests {
             (10u128.pow(37), 85.19564844077969),
             (10u128.pow(38), 87.49823353377374),
         ];
-        for (x, expected) in test_cases.iter() {
+        for (x, expected) in &test_cases {
             let x_big = U128::from_u128(*x);
             let result = ln(&x_big);
             assert!(

--- a/src/hazmat/float.rs
+++ b/src/hazmat/float.rs
@@ -70,11 +70,17 @@ const fn two_powf_normalized_lower_bound(exp: f64) -> f64 {
 /// Calculates an approximation of `2^exp` where `exp < 0`.
 /// The approximation is guaranteed to always be greater than `2^exp`.
 pub(crate) const fn two_powf_upper_bound(exp: f64) -> f64 {
-    debug_assert!(exp < 0.);
+    assert!(exp < 0.);
 
     let positive_exp = -exp;
 
     let int_part = floor(positive_exp);
+
+    // 2^(-1075) is smaller than f64 can represent.
+    if int_part > 1074. {
+        return 0.0;
+    }
+
     let frac_part = positive_exp - int_part;
 
     let int_res = two_powi(int_part as u32);

--- a/src/hazmat/gcd.rs
+++ b/src/hazmat/gcd.rs
@@ -1,6 +1,8 @@
 use core::num::NonZero;
 use crypto_bigint::{Limb, NonZero as CTNonZero, Unsigned, Word};
 
+use super::utils::first_limb;
+
 /// Calculates the greatest common divisor of `n` and `m`.
 /// By definition, `gcd(0, m) == m`.
 /// `n` must be non-zero.
@@ -23,7 +25,7 @@ where
     } else {
         // In this branch `n` is `Word::BITS` bits or shorter,
         // so we can safely take the first limb.
-        let n = n.as_limbs()[0].0;
+        let n = first_limb(n);
         if n > m { (n, m) } else { (m, n) }
     };
 

--- a/src/hazmat/jacobi.rs
+++ b/src/hazmat/jacobi.rs
@@ -4,6 +4,8 @@ pub(crate) use crypto_bigint::JacobiSymbol;
 
 use crypto_bigint::{Limb, NonZero as CTNonZero, Odd, Unsigned, Word};
 
+use super::utils::first_limb;
+
 /// Transforms `(a/p)` -> `(r/p)` for odd `p`, where the resulting `r` is odd, and `a = r * 2^s`.
 /// Takes a Jacobi symbol value, and returns `r` and the new Jacobi symbol,
 /// negated if the transformation changes parity.
@@ -24,7 +26,7 @@ fn reduce_numerator_long<T>(j: JacobiSymbol, a: Word, p: &T) -> (JacobiSymbol, W
 where
     T: Unsigned,
 {
-    apply_reduce_numerator(j, a, p.as_limbs()[0].0)
+    apply_reduce_numerator(j, a, first_limb(p))
 }
 
 fn reduce_numerator_short(j: JacobiSymbol, a: Word, p: Word) -> (JacobiSymbol, Word) {
@@ -39,7 +41,7 @@ fn apply_swap(j: JacobiSymbol, a: Word, p: Word) -> JacobiSymbol {
 }
 
 fn swap_long<T: Unsigned>(j: JacobiSymbol, a: Word, p: &Odd<T>) -> (JacobiSymbol, &Odd<T>, Word) {
-    let j = apply_swap(j, a, p.as_ref().as_limbs()[0].0);
+    let j = apply_swap(j, a, first_limb(p.as_ref()));
     (j, p, a)
 }
 
@@ -59,7 +61,7 @@ where
     // (-a/n) = (-1/n) * (a/n)
     //        = (-1)^((n-1)/2) * (a/n)
     //        = (-1 if n = 3 mod 4 else 1) * (a/n)
-    let result = if a_is_negative && p_long.as_ref().as_limbs()[0].0 & 3 == 3 {
+    let result = if a_is_negative && first_limb(p_long.as_ref()) & 3 == 3 {
         -result
     } else {
         result
@@ -75,7 +77,7 @@ where
     // Normalize input: at the end we want `a < p`, `p` odd, and both fitting into a `Word`.
     let (result, a, p): (JacobiSymbol, Word, Word) = if p_long.bits_vartime() <= Limb::BITS {
         let a = a_limb.0;
-        let p = p_long.as_ref().as_limbs()[0].0;
+        let p = first_limb(p_long.as_ref());
         (result, a % p, p)
     } else {
         let (result, a) = reduce_numerator_long(result, a_limb.0, p_long.as_ref());

--- a/src/hazmat/jacobi.rs
+++ b/src/hazmat/jacobi.rs
@@ -1,8 +1,6 @@
 //! Jacobi symbol calculation.
 
-pub(crate) use crypto_bigint::JacobiSymbol;
-
-use crypto_bigint::{Limb, NonZero as CTNonZero, Odd, Unsigned, Word};
+use crypto_bigint::{JacobiSymbol, Limb, NonZero as CTNonZero, Odd, Unsigned, Word};
 
 use super::utils::first_limb;
 

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -297,6 +297,11 @@ pub enum LucasCheck {
 /// prescribed by the FIPS.186-5 standard[^FIPS].
 ///
 /// [^FIPS]: FIPS-186.5 standard, <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf>
+#[expect(
+    clippy::needless_pass_by_value, // TODO: would be a breaking change, has to wait for 0.8
+    clippy::cognitive_complexity,
+    clippy::too_many_lines,
+)]
 pub fn lucas_test<T>(candidate: Odd<T>, base: impl LucasBase, check: LucasCheck) -> Primality
 where
     T: UnsignedWithMontyForm,

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -42,17 +42,14 @@ pub struct SelfridgeBase;
 
 impl LucasBase for SelfridgeBase {
     fn generate<T: UnsignedWithMontyForm>(&self, n: &Odd<T>) -> Result<(Word, Word, bool), Primality> {
-        let mut abs_d = 5;
-        let mut d_is_negative = false;
         let n_is_small = n.bits_vartime() < Word::BITS; // if true, `n` fits into one `Word`
         let small_n = first_limb(n.as_ref());
-        let mut attempts = 0;
-        loop {
-            if attempts >= MAX_ATTEMPTS {
-                panic!("internal error: cannot find (D/n) = -1 for {:?}", n)
-            }
 
-            if attempts >= ATTEMPTS_BEFORE_SQRT {
+        for ((abs_d, d_is_negative), attempts) in ((5..).step_by(2))
+            .zip([false, true].iter().copied().cycle())
+            .zip(0..MAX_ATTEMPTS)
+        {
+            if attempts == ATTEMPTS_BEFORE_SQRT {
                 let sqrt_n = n.floor_sqrt_vartime();
                 if &sqrt_n.wrapping_mul(&sqrt_n) == n.as_ref() {
                     return Err(Primality::Composite);
@@ -62,7 +59,15 @@ impl LucasBase for SelfridgeBase {
             let j = jacobi_symbol_vartime(abs_d, d_is_negative, n);
 
             if j == JacobiSymbol::MinusOne {
-                break;
+                // Calculate `q = (1 - d) / 4`.
+                // No remainder from division by 4, by construction of `d`.
+                let (abs_q, q_is_negative) = if d_is_negative {
+                    ((abs_d + 1) / 4, false)
+                } else {
+                    ((abs_d - 1) / 4, true)
+                };
+
+                return Ok((1, abs_q, q_is_negative));
             }
             if j == JacobiSymbol::Zero {
                 // Modification of Method A by Baillie, in an example to OEIS:A217120
@@ -75,21 +80,9 @@ impl LucasBase for SelfridgeBase {
                     return Err(Primality::Composite);
                 }
             }
-
-            attempts += 1;
-            d_is_negative = !d_is_negative;
-            abs_d += 2;
         }
 
-        // Calculate `q = (1 - d) / 4`.
-        // No remainder from division by 4, by construction of `d`.
-        let (abs_q, q_is_negative) = if d_is_negative {
-            ((abs_d + 1) / 4, false)
-        } else {
-            ((abs_d - 1) / 4, true)
-        };
-
-        Ok((1, abs_q, q_is_negative))
+        panic!("internal error: cannot find (D/n) = -1 for {:?}", n);
     }
 }
 
@@ -128,15 +121,8 @@ pub struct BruteForceBase;
 
 impl LucasBase for BruteForceBase {
     fn generate<T: UnsignedWithMontyForm>(&self, n: &Odd<T>) -> Result<(Word, Word, bool), Primality> {
-        let mut p = 3;
-        let mut attempts = 0;
-
-        loop {
-            if attempts >= MAX_ATTEMPTS {
-                panic!("internal error: cannot find (D/n) = -1 for {:?}", n)
-            }
-
-            if attempts >= ATTEMPTS_BEFORE_SQRT {
+        for (p, attempts) in (3..).zip(0..MAX_ATTEMPTS) {
+            if attempts == ATTEMPTS_BEFORE_SQRT {
                 let sqrt_n = n.floor_sqrt_vartime();
                 if &sqrt_n.wrapping_mul(&sqrt_n) == n.as_ref() {
                     return Err(Primality::Composite);
@@ -147,7 +133,7 @@ impl LucasBase for BruteForceBase {
             let j = jacobi_symbol_vartime(p * p - 4, false, n);
 
             if j == JacobiSymbol::MinusOne {
-                break;
+                return Ok((p, 1, false));
             }
             if j == JacobiSymbol::Zero {
                 // D = P^2 - 4 = (P - 2)(P + 2).
@@ -162,12 +148,9 @@ impl LucasBase for BruteForceBase {
                 };
                 return Err(primality);
             }
-
-            attempts += 1;
-            p += 1;
         }
 
-        Ok((p, 1, false))
+        panic!("internal error: cannot find (D/n) = -1 for {:?}", n);
     }
 }
 

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -395,7 +395,7 @@ where
     // Starting with k = 0
     let mut vk = two.clone(); // keeps V_k
     let mut uk = <T as UnsignedWithMontyForm>::MontyForm::zero(&params); // keeps U_k
-    let mut qk = one.clone(); // keeps Q^k
+    let mut qk = one; // keeps Q^k
 
     let mut temp = <T as UnsignedWithMontyForm>::MontyForm::zero(&params);
 
@@ -435,7 +435,7 @@ where
             mm.mul_assign(&mut temp, &d_m);
             if !p_is_one {
                 mm.mul_assign(&mut vk, &p);
-            };
+            }
             vk += &temp;
             vk.div_by_2_assign();
 
@@ -539,9 +539,8 @@ where
         uk *= &vk; // now `uk = U_{d * 2^s} = U_{n+1}`
         if uk == zero {
             return Primality::ProbablyPrime;
-        } else {
-            return Primality::Composite;
         }
+        return Primality::Composite;
     }
 
     // Double the index again:
@@ -552,9 +551,8 @@ where
     if check == LucasCheck::LucasV {
         if !lucas_v {
             return Primality::Composite;
-        } else {
-            return Primality::ProbablyPrime;
         }
+        return Primality::ProbablyPrime;
     }
 
     // The only remaining variant at this point.
@@ -622,7 +620,7 @@ mod tests {
         assert_eq!(
             BruteForceBase.generate(&Odd::new(U64::from(5u32)).unwrap()),
             Err(Primality::Prime)
-        )
+        );
     }
 
     #[test]
@@ -706,7 +704,7 @@ mod tests {
     }
 
     fn test_pseudoprimes<T: HasBaseType>(numbers: &[u32], base: T, check: LucasCheck, expected_result: bool) {
-        for num in numbers.iter() {
+        for num in numbers {
             let false_positive = is_pseudoprime::<T>(*num, check);
             let actual_expected_result = if false_positive { true } else { expected_result };
 
@@ -729,7 +727,7 @@ mod tests {
     #[test]
     fn strong_fibonacci_pseudoprimes() {
         // Can't use `test_pseudoprimes()` since `STRONG_FIBONACCI` is `U64`.
-        for num in pseudoprimes::STRONG_FIBONACCI.iter() {
+        for num in pseudoprimes::STRONG_FIBONACCI {
             assert!(lucas_test(Odd::new(*num).unwrap(), SelfridgeBase, LucasCheck::Regular).is_composite());
             assert!(lucas_test(Odd::new(*num).unwrap(), SelfridgeBase, LucasCheck::Strong).is_composite());
             assert!(lucas_test(Odd::new(*num).unwrap(), AStarBase, LucasCheck::LucasV).is_composite());

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -6,6 +6,7 @@ use super::{
     Primality,
     gcd::gcd_vartime,
     jacobi::{JacobiSymbol, jacobi_symbol_vartime},
+    utils::first_limb,
 };
 
 /// The maximum number of attempts to find `D` such that `(D/n) == -1`.
@@ -49,7 +50,7 @@ impl LucasBase for SelfridgeBase {
         let mut abs_d = 5;
         let mut d_is_negative = false;
         let n_is_small = n.bits_vartime() < Word::BITS; // if true, `n` fits into one `Word`
-        let small_n = n.as_ref().as_limbs()[0].0;
+        let small_n = first_limb(n.as_ref());
         let mut attempts = 0;
         loop {
             if attempts >= MAX_ATTEMPTS {

--- a/src/hazmat/lucas.rs
+++ b/src/hazmat/lucas.rs
@@ -1,13 +1,8 @@
 //! Lucas primality test.
 use core::num::NonZero;
-use crypto_bigint::{Limb, MontyForm, MontyMultiplier, Odd, Square, UnsignedWithMontyForm, Word};
+use crypto_bigint::{JacobiSymbol, Limb, MontyForm, MontyMultiplier, Odd, Square, UnsignedWithMontyForm, Word};
 
-use super::{
-    Primality,
-    gcd::gcd_vartime,
-    jacobi::{JacobiSymbol, jacobi_symbol_vartime},
-    utils::first_limb,
-};
+use super::{Primality, gcd::gcd_vartime, jacobi::jacobi_symbol_vartime, utils::first_limb};
 
 /// The maximum number of attempts to find `D` such that `(D/n) == -1`.
 // This is widely believed to be impossible.

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -174,6 +174,11 @@ const fn pseudoprime_probability(k: u32, t: u32, cap_m: u32) -> f64 {
 
     // `2.00743 ln(2) k` comes from Proposition 2 in [^Damgard], from the estimate for `(pi(2^k) - pi(2^{k-1}))^{-1}`.
 
+    const PI: f64 = core::f64::consts::PI;
+
+    // `2.00743 * ln(2) * 2^(-2)`
+    const COEFF: f64 = 0.3478611111678627;
+
     // Calculate the powers of 2 under the summations.
     //
     // Technically, only a few terms really contribute to the result, and the rest are extremely small in comparison.
@@ -193,11 +198,6 @@ const fn pseudoprime_probability(k: u32, t: u32, cap_m: u32) -> f64 {
         m += 1;
     }
 
-    const PI: f64 = core::f64::consts::PI;
-
-    // `2.00743 * ln(2) * 2^(-2)`
-    const COEFF: f64 = 0.3478611111678627;
-
     COEFF * k as f64 * (1. / two_powi(cap_m * t) + 8. * (PI * PI - 6.) / 3. * s)
 }
 
@@ -210,6 +210,7 @@ const fn pseudoprime_probability(k: u32, t: u32, cap_m: u32) -> f64 {
 /// This function implements the formula prescribed by the FIPS.186-5 standard[^FIPS].
 ///
 /// [^FIPS]: FIPS-186.5 standard, <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf>
+#[must_use]
 pub const fn minimum_mr_iterations(bit_length: u32, log2_target: u32) -> Option<usize> {
     let mut t = 1;
     while t <= log2_target.div_ceil(2) {
@@ -279,7 +280,7 @@ mod tests {
 
     fn test_composites(numbers: &[u32], expected_result: bool) {
         let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
-        for num in numbers.iter() {
+        for num in numbers {
             let base_2_false_positive = is_spsp(*num);
             let actual_expected_result = if base_2_false_positive { true } else { expected_result };
 
@@ -331,7 +332,7 @@ mod tests {
     fn strong_fibonacci_pseudoprimes() {
         let mut rng = ChaCha8Rng::from_seed(*b"01234567890123456789012345678901");
 
-        for num in pseudoprimes::STRONG_FIBONACCI.iter() {
+        for num in pseudoprimes::STRONG_FIBONACCI {
             let mr = MillerRabin::new(Odd::new(*num).unwrap());
             assert!(!mr.test_base_two().is_probably_prime());
             for _ in 0..1000 {

--- a/src/hazmat/miller_rabin.rs
+++ b/src/hazmat/miller_rabin.rs
@@ -58,7 +58,6 @@ impl<T: UnsignedWithMontyForm + RandomMod> MillerRabin<T> {
         } else {
             let candidate_minus_one = candidate.wrapping_sub(&one);
             let s = candidate_minus_one.trailing_zeros_vartime();
-            // Will not overflow because `candidate` is odd and greater than 1.
             let d = candidate_minus_one
                 .overflowing_shr_vartime(s)
                 .expect("shifting by `s` is within range by construction: `candidate` is odd and greater than 1");
@@ -166,6 +165,7 @@ composite number would survive an attempt to validate its primality.
     Probable Prime Test. Mathematics of Computation 61(203):177-194 (1993),
     <https://www.ams.org/journals/mcom/1993-61-203/S0025-5718-1993-1189518-9/S0025-5718-1993-1189518-9.pdf>
 */
+#[expect(clippy::as_conversions)] // `From` is not available in a `const fn`
 const fn pseudoprime_probability(k: u32, t: u32, cap_m: u32) -> f64 {
     // Simplify Eq. (2) from [^FIPS] by factoring out `2^{k-2}`, which makes it
     // p_{k,t} = 2.000743 ln(2) k 2^{-2} (
@@ -179,6 +179,14 @@ const fn pseudoprime_probability(k: u32, t: u32, cap_m: u32) -> f64 {
     // `2.00743 * ln(2) * 2^(-2)`
     const COEFF: f64 = 0.3478611111678627;
 
+    assert!(cap_m < i32::MAX as u32);
+    #[expect(clippy::cast_possible_wrap)] // small enough that a wrap won't happen
+    let signed_cap_m = cap_m as i32;
+
+    assert!(t < i32::MAX as u32);
+    #[expect(clippy::cast_possible_wrap)] // small enough that a wrap won't happen
+    let signed_t = t as i32;
+
     // Calculate the powers of 2 under the summations.
     //
     // Technically, only a few terms really contribute to the result, and the rest are extremely small in comparison.
@@ -186,13 +194,13 @@ const fn pseudoprime_probability(k: u32, t: u32, cap_m: u32) -> f64 {
     // Can be done if more performance is desired.
     let mut s = 0.;
     let mut m = 3i32;
-    while m <= cap_m as i32 {
+    while m <= signed_cap_m {
         let mut j = 2i32;
         while j <= m {
             // Note that we are using `two_powf_upper_bound()` which means we are getting a slightly larger result,
             // and therefore very slightly overestimating the resulting probability.
             // This means safety is not compromised.
-            s += two_powf_upper_bound((m - (m - 1) * (t as i32) - j) as f64 - (k - 1) as f64 / j as f64);
+            s += two_powf_upper_bound((m - (m - 1) * signed_t - j) as f64 - (k - 1) as f64 / j as f64);
             j += 1;
         }
         m += 1;
@@ -201,8 +209,11 @@ const fn pseudoprime_probability(k: u32, t: u32, cap_m: u32) -> f64 {
     COEFF * k as f64 * (1. / two_powi(cap_m * t) + 8. * (PI * PI - 6.) / 3. * s)
 }
 
-/// For a candidate of size `bit_length`, returns the minimum number of Miller-Rabin tests with random bases
-/// required for the probability of hitting a pseudoprime (that is, a composite for which all M-R tests pass)
+/// Returns the minimum number of Miller-Rabin tests with random bases
+/// required for the given bound on the probability of hitting a pseudoprime.
+///
+/// More formally, for a candidate of size `bit_length`, returns the minimum number of Miller-Rabin tests
+/// with random bases required for the probability of reporting a composite as a prime
 /// to be smaller than `2^{-log2_target}`.
 ///
 /// Returns `None` if the number of iterations could not be found for the given bounds.
@@ -210,6 +221,7 @@ const fn pseudoprime_probability(k: u32, t: u32, cap_m: u32) -> f64 {
 /// This function implements the formula prescribed by the FIPS.186-5 standard[^FIPS].
 ///
 /// [^FIPS]: FIPS-186.5 standard, <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf>
+#[expect(clippy::as_conversions)] // `From` is not available in a `const fn`
 #[must_use]
 pub const fn minimum_mr_iterations(bit_length: u32, log2_target: u32) -> Option<usize> {
     let mut t = 1;

--- a/src/hazmat/precomputed.rs
+++ b/src/hazmat/precomputed.rs
@@ -122,8 +122,12 @@ pub(crate) const SMALL_PRIMES: [SmallPrime; 2047] = [
     17863,
 ];
 
+// If anything goes wrong here, we'll get an error in compile time.
+#[expect(clippy::indexing_slicing)]
 pub(crate) const LAST_SMALL_PRIME: SmallPrime = SMALL_PRIMES[SMALL_PRIMES.len() - 1];
 
+// If anything goes wrong here, we'll get an error in compile time.
+#[expect(clippy::indexing_slicing, clippy::as_conversions, clippy::large_stack_arrays)]
 const fn create_reciprocals() -> [Reciprocal; SMALL_PRIMES.len()] {
     let mut arr = [Reciprocal::default(); SMALL_PRIMES.len()];
     let mut i = 0;

--- a/src/hazmat/primecount.rs
+++ b/src/hazmat/primecount.rs
@@ -82,14 +82,22 @@ where
     // Number of bits to scale by (fractional bits during division)
     // On 64 bit CPUs and x is a U64, we use 32 bits (1 limb * 32). Else 64.
     // On 32 bit CPUs and x is a U64, we use 32 bits (2 limb * 16). Else 64.
+    let limbs = u32::try_from(LIMBS).expect("the number of limbs fits into `u32`");
     let scale_bits = {
         cpubits! {
-            32 => { (LIMBS as u32 * 16).min(64) }
-            64 => { (LIMBS as u32 * 32).min(64) }
+            32 => { limbs.min(4).checked_mul(16) }
+            64 => { limbs.min(2).checked_mul(32) }
         }
-    };
-    let total_scale_bits = 2 * scale_bits;
+    }
+    .expect("scale bits fit into `u32`");
+
+    let total_scale_bits = scale_bits.checked_mul(2).expect("scale bits times 2 fit into `u32`");
+
     // Scaling factor for the denominators of the expansion terms, 2^64.
+    //
+    // The number of limbs needed for precision loss is very large,
+    // and in any case some precision loss is acceptable here.
+    #[expect(clippy::as_conversions, clippy::cast_precision_loss)]
     let denom_scale_factor = (1u128 << scale_bits) as f64;
 
     let ln_x = ln(x);
@@ -106,7 +114,16 @@ where
     // Scale up a float by 2^64, round, cast to u128 and then to a wide `Uint`.
     let f64_to_scaled_uint = |value: f64| -> NonZero<Uint<RHS_LIMBS>> {
         let scaled = value * denom_scale_factor;
+
+        #[expect(
+            clippy::as_conversions,
+            // We checked above that ln_x > 1, and `value` will be `ln_x` to a small power.
+            clippy::cast_sign_loss,
+            // `value` won't be big enough for truncation
+            clippy::cast_possible_truncation,
+        )]
         let scaled = libm::round(scaled).max(1.0) as u128;
+
         let denom = Uint::<RHS_LIMBS>::from_u128(scaled);
         NonZero::new(denom).expect("max(1.0) ensures value is at least 1")
     };
@@ -136,7 +153,9 @@ where
         .wrapping_add(&term4_scaled);
 
     // Descale by right-shifting
-    let li_x = sum_scaled >> scale_bits;
+    let li_x = sum_scaled
+        .overflowing_shr_vartime(scale_bits)
+        .expect("the scaling factor is small enough to not overflow");
     li_x.resize_checked()
         .expect("de-scaling should leave the high half zero")
 }
@@ -275,7 +294,11 @@ mod tests {
             };
             let delta = uint_to_u128(&delta);
             let estimate_128 = uint_to_u128(&estimate);
+
+            // Some precision loss is acceptable here
+            #[expect(clippy::as_conversions, clippy::cast_precision_loss)]
             let error = (delta as f64 / *pi_x as f64) * 100.0;
+
             assert!(
                 error < 2.2,
                 "10^{exponent}:\t{pi_x} - {estimate_128} = {delta}, err: {error:.2}"

--- a/src/hazmat/primecount.rs
+++ b/src/hazmat/primecount.rs
@@ -45,13 +45,14 @@ use crypto_bigint::{Concat, NonZero, Uint, cpubits};
 ///
 /// ## Discussion
 ///
-/// Assuming RH, the dominant error term in estimating $\pi(x)$ with $Li_{approx}(x)$ comes from truncating the asymptotic
-/// expansion of Li(x). While this truncation error is extremely small in relative terms, it is large in absolute terms.
+/// Assuming RH, the dominant error term in estimating $\pi(x)$ with $Li_{approx}(x)$
+/// comes from truncating the asymptotic expansion of Li(x).
+/// While this truncation error is extremely small in relative terms, it is large in absolute terms.
 /// Improving the Li(x) approximation to be the same order of magnitude as the Schoenfeld bound would require using
 /// hundreds of terms from the asymptotic series (or employing more complex methods like continued fractions for the
 /// remainder, which is beyond the scope of this simple approximation). In relative terms the error bound is
-/// approximately $2^{-33}$ (for 1024 bits) down to $\sim 2^{-41}$ (for 4096 bits). This corresponds to an extremely small
-/// percentage error (significantly less than $10^{-8}$ %).
+/// approximately $2^{-33}$ (for 1024 bits) down to $\sim 2^{-41}$ (for 4096 bits).
+/// This corresponds to an extremely small percentage error (significantly less than $10^{-8}$ %).
 ///
 /// It should be noted that while Li(x) is generally smaller than $\pi(x)$ for 'small' x, it is known that the sign of
 /// $\pi(x) - Li(x)$ changes infinitely often. It has been proven that there must be a crossing below $\sim 10^{316}$
@@ -73,6 +74,7 @@ use crypto_bigint::{Concat, NonZero, Uint, cpubits};
 ///
 /// [^Trudgian2014]: T. Trudgian, "Updating the error term in the prime number theorem",
 ///   [arXiv:1401.2689](https://arxiv.org/abs/1401.2689) (2014)
+#[must_use]
 pub fn estimate_primecount<const LIMBS: usize, const RHS_LIMBS: usize>(x: &Uint<LIMBS>) -> Uint<LIMBS>
 where
     Uint<LIMBS>: Concat<LIMBS, Output = Uint<RHS_LIMBS>>,
@@ -213,17 +215,23 @@ mod tests {
             candidate - reference
         };
         assert!(
-            reference.bits_vartime() - delta.bits_vartime() >= min_bit_diff,
-            "Estimate not close enough: delta has {} bits, reference has {} bits. Difference should be >= {}\nEstimate: {candidate},\nReference: {reference}",
+            reference.bits_vartime().abs_diff(delta.bits_vartime()) >= min_bit_diff,
+            concat!(
+                "Estimate not close enough: delta has {} bits, reference has {} bits. ",
+                "Difference should be >= {}\nEstimate: {},\nReference: {}"
+            ),
             delta.bits_vartime(),
             reference.bits_vartime(),
-            min_bit_diff
+            min_bit_diff,
+            candidate,
+            reference,
         );
     }
 
     #[test]
     fn pi_x_estimates_for_known_values() {
-        // List of known values for π(x), expressed as a tuple of `(π(x), exponent)`, where the `exponent` is used with base 10.
+        // List of known values for π(x), expressed as a tuple of `(π(x), exponent)`,
+        // where the `exponent` is used with base 10.
         let pi_xs: Vec<(u128, u32)> = vec![
             // The error is large for small x, so we skip them.
             // (4, 1),
@@ -256,7 +264,7 @@ mod tests {
             (157589269275973410412739598, 28),
             (1520698109714272166094258063, 29),
         ];
-        for (pi_x, exponent) in pi_xs.iter() {
+        for (pi_x, exponent) in &pi_xs {
             let pi_x_wide = U256::from_u128(*pi_x);
             let n = U256::from_u128(10u128.pow(*exponent));
             let estimate = estimate_primecount(&n);
@@ -280,13 +288,13 @@ mod tests {
 
         cpubits! {
             32 => {
-                (limbs[3].0 as u128) << 96
-                | (limbs[2].0 as u128) << 64
-                | (limbs[1].0 as u128) << 32
-                | limbs[0].0 as u128
+                u128::from(limbs[3].0) << 96
+                | u128::from(limbs[2].0) << 64
+                | u128::from(limbs[1].0) << 32
+                | u128::from(limbs[0].0)
             }
             64 => {
-                ((limbs[1].0 as u128) << 64) | limbs[0].0 as u128
+                (u128::from(limbs[1].0) << 64) | u128::from(limbs[0].0)
             }
         }
     }

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -6,12 +6,13 @@ use alloc::{vec, vec::Vec};
 use core::marker::PhantomData;
 use core::num::{NonZero, NonZeroU32};
 
-use crypto_bigint::{Limb, Odd, RandomBits, RandomBitsError, Unsigned, Word};
+use crypto_bigint::{Limb, Odd, RandomBits, RandomBitsError, Unsigned};
 use rand_core::CryptoRng;
 
 use super::{
     Primality,
     precomputed::{LAST_SMALL_PRIME, RECIPROCALS, SMALL_PRIMES, SmallPrime},
+    utils::{equals_primitive, first_limb},
 };
 use crate::{error::Error, presets::Flavor};
 
@@ -123,13 +124,6 @@ where
     }
 
     Ok(Odd::new(random).expect("the number is odd by construction"))
-}
-
-pub(crate) fn equals_primitive<T>(num: &T, primitive: Word) -> bool
-where
-    T: Unsigned,
-{
-    num.bits_vartime() <= Word::BITS && num.as_limbs()[0].0 == primitive
 }
 
 // The type we use to calculate incremental residues.
@@ -260,8 +254,7 @@ where
             self.last_round = true;
             // Can unwrap here since we just checked above that `incr_limit <= INCR_LIMIT`,
             // and `INCR_LIMIT` fits into `Residue`.
-            let incr_limit_small: Residue = incr_limit.as_limbs()[0]
-                .0
+            let incr_limit_small: Residue = first_limb(&incr_limit)
                 .try_into()
                 .expect("the increment limit should fit within `Residue`");
             incr_limit_small
@@ -469,7 +462,7 @@ where
     };
     let start_limit: SmallPrime = if start_bits <= max_prime_bits {
         // Can convert since we just checked the bit size
-        start.as_limbs()[0].0.try_into().expect("The number is in range")
+        first_limb(start).try_into().expect("The number is in range")
     } else {
         SmallPrime::MAX
     };

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -15,6 +15,50 @@ use super::{
 };
 use crate::{error::Error, presets::Flavor};
 
+#[cfg(not(feature = "alloc"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Residues {
+    residues: [SmallPrime; SMALL_PRIMES.len()],
+    length: usize,
+}
+
+#[cfg(not(feature = "alloc"))]
+impl Residues {
+    fn empty(length: usize) -> Self {
+        Self {
+            residues: [0; SMALL_PRIMES.len()],
+            length,
+        }
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &SmallPrime> {
+        self.residues.iter().take(self.length)
+    }
+
+    fn iter_mut(&mut self) -> impl Iterator<Item = &mut SmallPrime> {
+        self.residues.iter_mut().take(self.length)
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Residues(Vec<SmallPrime>);
+
+#[cfg(feature = "alloc")]
+impl Residues {
+    fn empty(length: usize) -> Self {
+        Self(vec![0; length])
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &SmallPrime> {
+        self.0.iter()
+    }
+
+    fn iter_mut(&mut self) -> impl Iterator<Item = &mut SmallPrime> {
+        self.0.iter_mut()
+    }
+}
+
 /// Decide how prime candidates are manipulated by setting certain bits before primality testing,
 /// influencing the range of the prime.
 #[derive(Debug, Clone, Copy)]
@@ -107,12 +151,7 @@ pub struct SmallFactorsSieve<T: Unsigned> {
     incr: Residue,
     incr_limit: Residue,
     safe_primes: bool,
-    #[cfg(feature = "alloc")]
-    residues: Vec<SmallPrime>,
-    #[cfg(not(feature = "alloc"))]
-    residues: [SmallPrime; SMALL_PRIMES.len()],
-    #[cfg(not(feature = "alloc"))]
-    residues_len: usize,
+    residues: Residues,
     max_bit_length: u32,
     produces_nothing: bool,
     starts_from_exception: bool,
@@ -173,12 +212,7 @@ where
             incr: 0, // This will ensure that `update_residues()` is called right away.
             incr_limit: 0,
             safe_primes,
-            #[cfg(feature = "alloc")]
-            residues: vec![0; residues_len],
-            #[cfg(not(feature = "alloc"))]
-            residues: [0; SMALL_PRIMES.len()],
-            #[cfg(not(feature = "alloc"))]
-            residues_len,
+            residues: Residues::empty(residues_len),
             max_bit_length,
             produces_nothing,
             starts_from_exception,
@@ -207,13 +241,9 @@ where
         self.incr = 0;
 
         // Re-calculate residues. This is taking up most of the sieving time.
-        #[cfg(feature = "alloc")]
-        let residues_len = self.residues.len();
-        #[cfg(not(feature = "alloc"))]
-        let residues_len = self.residues_len;
-        for (i, rec) in RECIPROCALS.iter().enumerate().take(residues_len) {
-            let rem = self.base.rem_limb_with_reciprocal(rec);
-            self.residues[i] = rem.0 as SmallPrime;
+        for (residue, reciprocal) in self.residues.iter_mut().zip(RECIPROCALS.iter()) {
+            let rem = self.base.rem_limb_with_reciprocal(reciprocal);
+            *residue = rem.0 as SmallPrime;
         }
 
         // Find the increment limit.
@@ -242,11 +272,7 @@ where
 
     // Returns `true` if the current `base + incr` is divisible by any of the small primes.
     fn current_is_composite(&self) -> bool {
-        #[cfg(feature = "alloc")]
-        let residues_len = self.residues.len();
-        #[cfg(not(feature = "alloc"))]
-        let residues_len = self.residues_len;
-        self.residues.iter().take(residues_len).enumerate().any(|(i, m)| {
+        self.residues.iter().enumerate().any(|(i, m)| {
             let d = SMALL_PRIMES[i] as Residue;
             let r = (*m as Residue + self.incr) % d;
 

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -112,13 +112,13 @@ where
     // `bit_length - 1`-th bit exists since `bit_length` is non-zero.
     match set_bits {
         SetBits::None => {}
-        SetBits::Msb => random.set_bit_vartime(bit_length - 1, true),
+        SetBits::Msb => random.set_bit_vartime(bit_length.checked_sub(1).expect("`bit_length` is non-zero"), true),
         SetBits::TwoMsb => {
-            random.set_bit_vartime(bit_length - 1, true);
+            random.set_bit_vartime(bit_length.checked_sub(1).expect("`bit_length` is non-zero"), true);
             // We could panic here, but since the primary purpose of `TwoMsb` is to ensure the bit length
             // of the product of two numbers, ignoring this for `bit_length = 1` leads to the desired result.
             if bit_length > 1 {
-                random.set_bit_vartime(bit_length - 2, true);
+                random.set_bit_vartime(bit_length.checked_sub(2).expect("`bit_length` is > 1"), true);
             }
         }
     }

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -239,7 +239,8 @@ where
         // Re-calculate residues. This is taking up most of the sieving time.
         for (residue, reciprocal) in self.residues.iter_mut().zip(RECIPROCALS.iter()) {
             let rem = self.base.rem_limb_with_reciprocal(reciprocal);
-            *residue = rem.0 as SmallPrime;
+            *residue = SmallPrime::try_from(rem.0)
+                .expect("the remainder is smaller than the divisor, which is of type `SmallPrime`");
         }
 
         // Find the increment limit.
@@ -267,9 +268,12 @@ where
 
     // Returns `true` if the current `base + incr` is divisible by any of the small primes.
     fn current_is_composite(&self) -> bool {
-        self.residues.iter().enumerate().any(|(i, m)| {
-            let d = SMALL_PRIMES[i] as Residue;
-            let r = (*m as Residue + self.incr) % d;
+        self.residues.iter().zip(SMALL_PRIMES.iter()).any(|(residue, prime)| {
+            let d = NonZero::new(Residue::from(*prime)).expect("all `SMALL_PRIMES` are odd");
+            let r = (Residue::from(*residue)
+                .checked_add(self.incr)
+                .expect("the increment is reset in `update_residues()` if it grows too large"))
+                % d;
 
             // A trick from "Safe Prime Generation with a Combined Sieve" by Michael J. Wiener
             // (https://eprint.iacr.org/2003/186).
@@ -277,7 +281,7 @@ where
             // If `(n - 1)/2 mod d == (d - 1)/2`, it means that `n mod d == 0`.
             // In other words, we are checking the remainder of `n mod d`
             // for virtually no additional cost.
-            r == 0 || (self.safe_primes && r == (d - 1) >> 1)
+            r == 0 || (self.safe_primes && r == (d.get().checked_sub(1).expect("`d` is NonZero")) >> 1)
         })
     }
 
@@ -299,7 +303,10 @@ where
             }
         };
 
-        self.incr += 2;
+        self.incr = self
+            .incr
+            .checked_add(2)
+            .expect("the increment is reset in `update_residues()` if it grows too large");
         result
     }
 
@@ -450,7 +457,9 @@ where
 
     let start_bits = start.bits_vartime();
 
-    let max_prime_bits = SmallPrime::BITS - LAST_SMALL_PRIME.leading_zeros();
+    let max_prime_bits = SmallPrime::BITS
+        .checked_sub(LAST_SMALL_PRIME.leading_zeros())
+        .expect("the number of leading zeros is not greater than the total number of bits");
 
     // Both the limits defined by `start`, and by the sqrt of the end of the interval are large,
     // so we use all the available factors.

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -163,9 +163,11 @@ where
     /// Note that `start` is adjusted to `2`, or the next `1 mod 2` number (`safe_primes = false`);
     /// and `5`, or `3 mod 4` number (`safe_primes = true`).
     ///
-    /// Panics if `max_bit_length` greater than the precision of `start`.
-    ///
     /// If `safe_primes` is `true`, both the returned `n` and `n/2` are sieved.
+    ///
+    /// # Panics
+    ///
+    /// * if `max_bit_length` greater than the precision of `start`.
     pub fn new(start: T, max_bit_length: NonZeroU32, safe_primes: bool) -> Result<Self, Error> {
         let max_bit_length_nz = max_bit_length;
         let max_bit_length = max_bit_length.get();
@@ -373,6 +375,10 @@ where
     /// Some bits may be guaranteed to set depending on the requested `set_bits`.
     ///
     /// Depending on the requested `flavor`, additional filters may be applied.
+    ///
+    /// # Panics
+    ///
+    /// * if `max_bit_length` is zero.
     pub const fn new(flavor: Flavor, max_bit_length: u32, set_bits: SetBits) -> Result<Self, Error> {
         match flavor {
             Flavor::Any => {

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -315,10 +315,9 @@ where
         // Main loop
 
         while self.update_residues() {
-            match self.maybe_next() {
-                Some(x) => return Some(x),
-                None => continue,
-            };
+            if let Some(x) = self.maybe_next() {
+                return Some(x);
+            }
         }
         None
     }
@@ -374,7 +373,7 @@ where
     /// Some bits may be guaranteed to set depending on the requested `set_bits`.
     ///
     /// Depending on the requested `flavor`, additional filters may be applied.
-    pub fn new(flavor: Flavor, max_bit_length: u32, set_bits: SetBits) -> Result<Self, Error> {
+    pub const fn new(flavor: Flavor, max_bit_length: u32, set_bits: SetBits) -> Result<Self, Error> {
         match flavor {
             Flavor::Any => {
                 if max_bit_length < 2 {
@@ -393,7 +392,7 @@ where
                 }
             }
         }
-        let max_bit_length = NonZero::new(max_bit_length).expect("`bit_length` should be non-zero");
+        let max_bit_length = NonZero::new(max_bit_length).expect("`max_bit_length` is non-zero");
         Ok(Self {
             max_bit_length,
             safe_primes: match flavor {
@@ -555,7 +554,7 @@ mod tests {
 
         // The start of the interval is lower than the last prime,
         // so the number of factors is determined by it.
-        let len = trial_primes_num(&U64::from(LAST_SMALL_PRIME as u64 - 1), 64.try_into().unwrap());
+        let len = trial_primes_num(&U64::from(u64::from(LAST_SMALL_PRIME) - 1), 64.try_into().unwrap());
         assert_eq!(len, SMALL_PRIMES.len() - 1);
     }
 
@@ -602,7 +601,7 @@ mod tests {
             let factors_and_powers = factorize64(num_u64);
             let factors = factors_and_powers.into_keys().collect::<Vec<_>>();
 
-            assert!(factors[0] > max_prime as u64);
+            assert!(factors[0] > u64::from(max_prime));
         }
     }
     #[test]
@@ -620,14 +619,14 @@ mod tests {
             .take(100)
         {
             // For 32-bit targets
-            #[allow(clippy::useless_conversion)]
-            let num_u64: u64 = num.as_words()[0].into();
+            #[expect(clippy::useless_conversion)]
+            let num_u64 = u64::from(num.as_words()[0]);
             assert!(num_u64.leading_zeros() == 32);
 
             let factors_and_powers = factorize64(num_u64);
             let factors = factors_and_powers.into_keys().collect::<Vec<_>>();
 
-            assert!(factors[0] > max_prime as u64);
+            assert!(factors[0] > u64::from(max_prime));
         }
     }
 

--- a/src/hazmat/sieve.rs
+++ b/src/hazmat/sieve.rs
@@ -132,11 +132,13 @@ type Residue = u32;
 
 // The maximum increment that won't overflow the type we use to calculate residues of increments:
 // we need `(max_prime - 1) + max_incr <= Type::MAX`.
+#[expect(clippy::as_conversions)] // `From` is not available in a const context
 const INCR_LIMIT: Residue = Residue::MAX - LAST_SMALL_PRIME as Residue + 1;
 
 /// An iterator returning numbers with up to and including given bit length,
 /// starting from a given number, that are not multiples of the first 2048 small primes.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[expect(clippy::struct_excessive_bools)] // There's no point in custom enums here
 pub struct SmallFactorsSieve<T: Unsigned> {
     // Instead of dividing a big integer by small primes every time (which is slow),
     // we keep a "base" and a small increment separately,
@@ -533,6 +535,7 @@ where
 }
 
 #[cfg(test)]
+#[expect(clippy::indexing_slicing)]
 mod tests {
 
     use alloc::format;

--- a/src/hazmat/utils.rs
+++ b/src/hazmat/utils.rs
@@ -1,0 +1,12 @@
+use crypto_bigint::{Unsigned, Word};
+
+pub(crate) fn first_limb<T: Unsigned>(num: &T) -> Word {
+    num.as_limbs().first().expect("a big integer has at least one limb").0
+}
+
+pub(crate) fn equals_primitive<T>(num: &T, primitive: Word) -> bool
+where
+    T: Unsigned,
+{
+    num.bits_vartime() <= Word::BITS && first_limb(num) == primitive
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,6 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
-#![deny(unsafe_code)]
-#![warn(
-    clippy::mod_module_files,
-    missing_docs,
-    missing_debug_implementations,
-    missing_copy_implementations,
-    rust_2018_idioms,
-    trivial_casts,
-    trivial_numeric_casts,
-    unused_qualifications,
-    clippy::unwrap_used
-)]
 
 #[cfg(any(feature = "alloc", test))]
 extern crate alloc;

--- a/src/multicore.rs
+++ b/src/multicore.rs
@@ -98,9 +98,10 @@ where
 ///
 /// Uses `threadcount` cores to parallelize the prime search.
 ///
-/// Panics if `bit_length` is less than the bit length of the smallest possible prime with the requested `flavor`.
+/// # Panics
 ///
-/// Panics if the platform is unable to spawn threads.
+/// * if `bit_length` is less than the bit length of the smallest possible prime with the requested `flavor`.
+/// * if the platform is unable to spawn threads.
 pub fn random_prime<T, R>(rng: &mut R, flavor: Flavor, bit_length: u32, threadcount: usize) -> T
 where
     T: UnsignedWithMontyForm + RandomBits + RandomMod,

--- a/src/multicore.rs
+++ b/src/multicore.rs
@@ -32,9 +32,8 @@ where
         .build()
         .expect("If the platform can spawn threads, then this call will work.");
 
-    let iter = match SieveIterator::new(rng, sieve_factory)? {
-        Some(iter) => iter,
-        None => return Ok(None),
+    let Some(iter) = SieveIterator::new(rng, sieve_factory)? else {
+        return Ok(None);
     };
 
     threadpool.install(|| {
@@ -61,14 +60,13 @@ where
     /// Creates a new chained iterator producing results from sieves returned from `sieve_factory`.
     pub fn new(rng: &'a mut R, sieve_factory: S) -> Result<Option<Self>, Error> {
         let mut sieve_factory = sieve_factory;
-        let sieve = match sieve_factory.make_sieve(rng, None)? {
-            Some(sieve) => sieve,
-            None => return Ok(None),
+        let Some(sieve) = sieve_factory.make_sieve(rng, None)? else {
+            return Ok(None);
         };
         Ok(Some(Self {
             sieve_factory,
-            rng,
             sieve,
+            rng,
         }))
     }
 }

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -5,7 +5,7 @@ use crate::{
     generic::sieve_and_find,
     hazmat::{
         AStarBase, ConventionsTestResult, LucasCheck, MillerRabin, Primality, SetBits, SmallFactorsSieveFactory,
-        conventions_test, equals_primitive, lucas_test,
+        conventions_test, equals_primitive, first_limb, lucas_test,
     },
 };
 
@@ -106,7 +106,7 @@ where
     // Safe primes are always of the form 4k + 3 (i.e. n ≡ 3 mod 4)
     // The last two digits of a binary number give you its value modulo 4.
     // Primes p=4n+3 will always end in 11 in binary because p ≡ 3 mod 4.
-    if candidate.as_limbs()[0].0 & 3 != 3 {
+    if first_limb(candidate) & 3 != 3 {
         return false;
     }
 

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -84,8 +84,7 @@ where
 
     match lucas_test(odd_candidate, AStarBase, LucasCheck::Bpsw21) {
         Primality::Composite => false,
-        Primality::Prime => true,
-        Primality::ProbablyPrime => true,
+        Primality::Prime | Primality::ProbablyPrime => true,
     }
 }
 
@@ -434,7 +433,7 @@ mod tests_openssl {
         for _ in 0..100 {
             let p: U128 = random_prime(&mut rng, Flavor::Any, 128);
             let p_bn = to_openssl(&p);
-            assert!(openssl_is_prime(&p_bn, &mut ctx), "OpenSSL reports {p} as composite",);
+            assert!(openssl_is_prime(&p_bn, &mut ctx), "OpenSSL reports {p} as composite");
         }
 
         let mr_iterations = minimum_mr_iterations(U128::BITS, 100).unwrap();

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -22,9 +22,11 @@ pub enum Flavor {
 ///
 /// The returned prime will have its MSB set.
 ///
-/// Panics if `bit_length` is less than the bit length of the smallest possible prime with the requested `flavor`.
-///
 /// See [`is_prime`] for details about the performed checks.
+///
+/// # Panics
+///
+/// * if `bit_length` is less than the bit length of the smallest possible prime with the requested `flavor`.
 pub fn random_prime<T, R>(rng: &mut R, flavor: Flavor, bit_length: u32) -> T
 where
     T: UnsignedWithMontyForm + RandomBits + RandomMod,


### PR DESCRIPTION
- add the changelog for #118 
- bump codecov-action to v7
- extract alloc/no-alloc logic of residues into a type
- fix potentially redundant work in Lucas bases generation where a perfect square check is executed multiple times (very unlikely to be hit in practice, but still)
- enable more pedantic clippy lints and add explicit exceptions/`expect()` where necessary